### PR TITLE
feat: configure deployment for open-learn.app

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+open-learn.app

--- a/src/composables/useLessons.js
+++ b/src/composables/useLessons.js
@@ -96,7 +96,7 @@ export function useLessons() {
   function getShareUrl(workshopSlug) {
     const sourceUrl = getSourceForSlug(workshopSlug)
     if (!sourceUrl) return null
-    return `https://felixboehm.github.io/open-learn/#/add?source=${encodeURIComponent(sourceUrl)}`
+    return `https://open-learn.app/#/add?source=${encodeURIComponent(sourceUrl)}`
   }
 
   // Load a remote content source's languages and workshops

--- a/src/views/Creators.vue
+++ b/src/views/Creators.vue
@@ -72,7 +72,7 @@
       <h3 class="text-lg font-semibold text-foreground mb-3">{{ t('shareTitle') }}</h3>
       <p class="text-sm text-muted-foreground mb-3">{{ t('shareDesc') }}</p>
       <div class="p-3 rounded-lg bg-accent/30 font-mono text-xs text-muted-foreground break-all">
-        https://felixboehm.github.io/open-learn/#/add?source=https://YOUR-USER.github.io/YOUR-REPO/index.yaml
+        https://open-learn.app/#/add?source=https://YOUR-USER.github.io/YOUR-REPO/index.yaml
       </div>
     </div>
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig(({ command }) => ({
     // Only use SSL in dev mode, not for preview/build
     ...(command === 'serve' && !process.env.CI ? [basicSsl()] : [])
   ],
-  base: '/open-learn/',
+  base: '/',
   server: {
     https: command === 'serve' && !process.env.CI,
     cors: true  // Enable CORS for cross-origin requests


### PR DESCRIPTION
## Summary
- Change Vite `base` from `/open-learn/` to `/` for root domain deployment
- Add `CNAME` file (`open-learn.app`) so GitHub Pages preserves the custom domain on deploy
- Update hardcoded share URLs from `felixboehm.github.io/open-learn` to `open-learn.app`

## Test plan
- [ ] Merge and verify `open-learn.app` serves the app
- [ ] Verify `open-learn.app/#/add?source=...` works
- [ ] All 101 tests pass