### PR TITLE
fix(ci): restore app build+deploy, remove redirect loop

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,47 +1,62 @@
-name: Deploy redirect to Pages
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
 on:
+  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
+  # Build and deploy job
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Create redirect page
-        run: |
-          mkdir -p _site
-          cat > _site/index.html << 'HTML'
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <meta charset="UTF-8">
-            <meta http-equiv="refresh" content="0; url=https://open-learn.app">
-            <link rel="canonical" href="https://open-learn.app">
-            <title>Redirecting to open-learn.app</title>
-          </head>
-          <body>
-            <p>This project has moved to <a href="https://open-learn.app">open-learn.app</a></p>
-          </body>
-          </html>
-          HTML
-          cp _site/index.html _site/404.html
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./dist"
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- The deploy workflow was replaced with a redirect page pointing to `open-learn.app`
- Since this repo IS `open-learn.app` (via CNAME), it caused an infinite redirect loop
- Restores the original `pnpm build` + deploy workflow

## Test plan
- [ ] Merge and verify https://open-learn.app/ loads the app instead of redirecting