### PR TITLE
fix: move mobile play button higher to avoid footer overlap

### DIFF
--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -247,7 +247,7 @@
       v-if="lesson"
       size="icon"
       @click="togglePlayPause"
-      class="md:hidden fixed bottom-6 right-6 w-16 h-16 rounded-full shadow-lg text-3xl z-50"
+      class="md:hidden fixed bottom-20 right-6 w-16 h-16 rounded-full shadow-lg text-3xl z-50"
       :title="isPlaying ? $t('nav.pause') : $t('nav.play')"
       :aria-label="isPlaying ? $t('nav.pauseAudio') : $t('nav.playAudio')">
       {{ isPlaying ? '⏸' : '▶️' }}


### PR DESCRIPTION
## Summary
- Moved floating play/pause button from `bottom-6` to `bottom-20` on mobile
- Prevents the button from covering the "Next Lesson" link in the footer

## Test plan
- [ ] On mobile: scroll to bottom of a lesson, verify play button doesn't overlap footer
- [ ] Verify play button is still easily reachable