### PR TITLE
fix: preserve label filter when navigating to next lesson

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -191,7 +191,7 @@
         <!-- Next Lesson button (right-aligned) -->
         <router-link
           v-if="isLessonPage && footerNextLesson"
-          :to="`/${lessonLearning}/${lessonWorkshop}/lesson/${footerNextLesson}`"
+          :to="{ path: `/${lessonLearning}/${lessonWorkshop}/lesson/${footerNextLesson}`, query: route.query.label ? { label: route.query.label } : {} }"
           class="ml-auto">
           <Button size="sm">
             {{ $t('lesson.nextLesson') }} {{ isRtl ? '←' : '→' }}

--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -621,7 +621,9 @@ watch(currentItem, async (newItem) => {
 // Auto-advance to next lesson when audio playback finishes
 watch(playbackFinished, (finished) => {
   if (finished && nextLessonNumber.value) {
-    router.replace(`/${learning.value}/${workshop.value}/lesson/${nextLessonNumber.value}?autoplay=true`)
+    const query = { autoplay: 'true' }
+    if (activeLabel.value) query.label = activeLabel.value
+    router.replace({ path: `/${learning.value}/${workshop.value}/lesson/${nextLessonNumber.value}`, query })
   }
 })
 


### PR DESCRIPTION
## Summary
- Footer "Next Lesson" link now includes `?label=` when a label filter is active
- Autoplay auto-advance also preserves the label filter

## Test plan
- [ ] Filter by label → click "Next Lesson" → label filter still active on next lesson
- [ ] Filter by label → let audio finish → auto-advance preserves label filter
- [ ] No label filter → next lesson works as before (no extra query param)