### PR TITLE
fix: resolve audio 404 for remote workshops

### DIFF
--- a/src/composables/useLessons.js
+++ b/src/composables/useLessons.js
@@ -31,6 +31,9 @@ function parseSource(source) {
 // Default content sources loaded from default-sources.yaml
 let defaultContentSources = []
 
+// Module-level singleton state (shared across all useLessons() calls)
+const workshopSlugMap = ref({}) // slug → URL mapping for remote workshops
+
 async function loadDefaultSources() {
   if (defaultContentSources.length > 0) return defaultContentSources
   try {
@@ -50,7 +53,6 @@ export function useLessons() {
   const availableContent = ref({})
   const languageCodes = ref({}) // Store language codes
   const workshopCodes = ref({}) // Store workshop codes
-  const workshopSlugMap = ref({}) // slug → URL mapping for remote workshops
   const workshopMeta = ref({}) // { lang: { workshop: { title, description } } }
   const isLoading = ref(false)
 


### PR DESCRIPTION
## Summary
- `workshopSlugMap` was created inside `useLessons()`, so each caller got a separate empty instance
- `useAudio.js` called `useLessons()` independently, getting an empty slug map
- `resolveWorkshopKey('portugiesisch')` returned `'portugiesisch'` instead of `https://open-learn.app/workshop-portugiesisch/deutsch/portugiesisch`
- Audio URL was built as `/lessons/deutsch/portugiesisch/...` (local, 404) instead of the remote URL
- Fix: move `workshopSlugMap` to module level so it's a true singleton shared across all callers

## Test plan
- [x] Open a remote workshop lesson (e.g. Portugiesisch lesson 2)
- [x] Verify audio files load and play correctly
- [x] Check browser console for correct audio base URL (should start with `https://open-learn.app/workshop-portugiesisch/`)