### PR TITLE
fix: media session artwork 404

### DIFF
--- a/src/composables/useAudio.js
+++ b/src/composables/useAudio.js
@@ -177,7 +177,7 @@ function setupMediaSession(lessonTitle, learning, workshop) {
   }
 
   const baseUrl = import.meta.env.BASE_URL
-  const artworkUrl = `${baseUrl}audio-test-artwork.svg` // Reuse existing artwork
+  const artworkUrl = `${baseUrl}favicon.svg`
 
   navigator.mediaSession.metadata = new MediaMetadata({
     title: lessonTitle,


### PR DESCRIPTION
## Summary
- `audio-test-artwork.svg` doesn't exist in public/, causing a 404 on every audio play
- Replaced with `favicon.svg` which exists

## Test plan
- [x] Play audio on a lesson → no 404 in network tab