### PR TITLE
fix: multiple-choice without validation shows green on first click

### DIFF
--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -440,7 +440,11 @@ function toggleDraftOption(example, optIdx) {
   } else {
     drafts[key].splice(idx, 1)
   }
-  validateMcLive(example)
+  if (!hasValidation(example)) {
+    submitAnswer(example)
+  } else {
+    validateMcLive(example)
+  }
 }
 
 function validateMcLive(example) {
@@ -483,7 +487,8 @@ function submitAnswer(example) {
     if (!userAnswer) return
   } else if (type === 'multiple-choice') {
     userAnswer = drafts[draftKey(example)]
-    if (!Array.isArray(userAnswer) || userAnswer.length === 0) return
+    if (!Array.isArray(userAnswer)) return
+    if (userAnswer.length === 0 && hasValidation(example)) return
   } else if (type === 'select') {
     userAnswer = getDraftSelect(example)
     if (userAnswer === null) return


### PR DESCRIPTION
## Summary
- Multiple-choice (checkbox) examples without validation now turn green on first interaction
- Previously required a submission which never happened without validation logic
- Allows empty selection to still count as interacted

## Test plan
- [x] Click a checkbox on a multiple-choice without validation → card turns green
- [x] Deselect all checkboxes → card stays green
- [x] Multiple-choice with validation still works as before (green only when correct)