### PR TITLE
fix: use workshop image for Media Session artwork

### DIFF
--- a/src/composables/useAudio.js
+++ b/src/composables/useAudio.js
@@ -3,7 +3,7 @@ import { useLessons } from './useLessons'
 import { useProgress } from './useProgress'
 
 // Get lesson composable for language codes
-const { getLanguageCode, getWorkshopCode, resolveWorkshopKey } = useLessons()
+const { getLanguageCode, getWorkshopCode, resolveWorkshopKey, getWorkshopMeta } = useLessons()
 
 // Get progress composable for learned items
 const { areAllItemsLearned } = useProgress()
@@ -184,7 +184,8 @@ function setupMediaSession(lessonTitle, learning, workshop) {
   }
 
   const baseUrl = import.meta.env.BASE_URL
-  const artworkUrl = `${baseUrl}favicon.svg`
+  const meta = getWorkshopMeta(learning, workshop)
+  const artworkUrl = meta.image || `${baseUrl}favicon.svg`
 
   navigator.mediaSession.metadata = new MediaMetadata({
     title: lessonTitle,


### PR DESCRIPTION
## Summary
- Media Session artwork (lock screen) now uses workshop's `image` from metadata
- Falls back to `favicon.svg` when no workshop image is configured
- Workshops can provide their own thumbnail via the `image` field in `workshops.yaml`

## Test plan
- [ ] Play audio on a workshop without image → favicon shown on lock screen
- [ ] Add `image` field to a workshop → workshop image shown on lock screen