### PR TITLE
fix: example click moves autoplay position without overlapping audio

### DIFF
--- a/src/composables/useAudio.js
+++ b/src/composables/useAudio.js
@@ -617,22 +617,6 @@ async function playSingleItem(index, settings) {
     // Set up event handlers
     audio.onended = () => {
       console.log('⏹️ Single item audio ended')
-
-      // If there's an answer right after this (next item), play it too
-      const nextItem = readingQueue.value[index + 1]
-      if (nextItem &&
-          nextItem.sectionIdx === item.sectionIdx &&
-          nextItem.exampleIdx === item.exampleIdx &&
-          nextItem.type === 'answer' &&
-          nextItem.audioUrl) {
-
-        const nextAudio = audioElements.value[nextItem.audioUrl]
-        if (nextAudio) {
-          console.log('📢 Playing answer too')
-          nextAudio.currentTime = 0
-          nextAudio.play().catch(e => console.error('Error playing answer:', e))
-        }
-      }
     }
 
     audio.onerror = (e) => {


### PR DESCRIPTION
## Summary
- When autoplay is active: clicking an example already correctly moves playback there (no change needed)
- When paused/stopped: removed auto-chaining of answer audio in `playSingleItem`, which could create a second audio stream that overlaps when autoplay resumes

## Test plan
- [ ] During autoplay: click an example → playback jumps there, continues normally
- [ ] When paused: click an example → plays question only, no answer auto-play
- [ ] Resume autoplay after clicking → no overlapping audio