### PR TITLE
feat: loading spinner on play button while audio preloads

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -75,10 +75,12 @@
             variant="ghost"
             size="icon"
             @click="togglePlayPause"
+            :disabled="isLoadingAudio"
             class="hidden md:flex bg-white/20 border-2 border-white/50 text-white hover:bg-white/30 hover:text-white rounded-full w-12 h-12 text-2xl flex-shrink-0"
-            :title="isPlaying ? $t('nav.pause') : $t('nav.play')"
-            :aria-label="isPlaying ? $t('nav.pauseAudio') : $t('nav.playAudio')">
-            {{ isPlaying ? '⏸' : '▶️' }}
+            :title="isLoadingAudio ? $t('nav.loading') : (isPlaying ? $t('nav.pause') : $t('nav.play'))"
+            :aria-label="isLoadingAudio ? $t('nav.loadingAudio') : (isPlaying ? $t('nav.pauseAudio') : $t('nav.playAudio'))">
+            <span v-if="isLoadingAudio" class="animate-spin">⏳</span>
+            <span v-else>{{ isPlaying ? '⏸' : '▶️' }}</span>
           </Button>
 
           <!-- Results / Lesson# toggle button -->
@@ -213,7 +215,7 @@ const { locale } = useI18n()
 const pageTitle = ref('🎓 Open Learn')
 const showLanguageMenu = ref(false)
 
-const { isPlaying, play, pause, resume } = useAudio()
+const { isLoadingAudio, isPlaying, play, pause, resume } = useAudio()
 const { settings } = useSettings()
 const { availableContent, getWorkshopMeta, workshopMeta, loadAvailableContent, loadWorkshopsForLanguage } = useLessons()
 const { selectedLanguage, getFlag, setLanguage } = useLanguage()

--- a/src/composables/useAudio.js
+++ b/src/composables/useAudio.js
@@ -9,6 +9,7 @@ const { getLanguageCode, getWorkshopCode, resolveWorkshopKey, getWorkshopMeta } 
 const { areAllItemsLearned } = useProgress()
 
 // Shared audio state (singleton pattern)
+const isLoadingAudio = ref(false)
 const isPlaying = ref(false)
 const isPaused = ref(false)
 const currentItemIndex = ref(-1)
@@ -256,6 +257,7 @@ async function initializeAudio(lesson, learning, workshop, settings) {
   lessonMetadata.value = { learning, workshop, number: lesson.number }
 
   playbackFinished.value = false
+  isLoadingAudio.value = true
   readingQueue.value = buildReadingQueue(lesson, learning, workshop, settings)
 
   console.log('📋 Built reading queue with', readingQueue.value.length, 'items')
@@ -272,6 +274,7 @@ async function initializeAudio(lesson, learning, workshop, settings) {
   // Pre-load audio files (filtered by manifest if available)
   audioElements.value = await preloadAudioFiles(readingQueue.value, manifest)
 
+  isLoadingAudio.value = false
   currentItemIndex.value = -1
   isPlaying.value = false
   isPaused.value = false
@@ -722,6 +725,7 @@ function cleanup() {
 
 export function useAudio() {
   return {
+    isLoadingAudio,
     isPlaying,
     isPaused,
     playbackFinished,

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -7,6 +7,7 @@
     "play": "تشغيل",
     "pauseAudio": "إيقاف الصوت",
     "playAudio": "تشغيل الصوت",
+    "loadingAudio": "جاري تحميل الصوت...",
     "assessmentResults": "نتائج التقييم",
     "coach": "المدرب",
     "learningItems": "عناصر التعلم",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -7,6 +7,7 @@
     "play": "Abspielen",
     "pauseAudio": "Audio pausieren",
     "playAudio": "Audio abspielen",
+    "loadingAudio": "Audio wird geladen...",
     "assessmentResults": "Ergebnisse",
     "coach": "Coach",
     "learningItems": "Lernelemente",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -7,6 +7,7 @@
     "play": "Play",
     "pauseAudio": "Pause audio",
     "playAudio": "Play audio",
+    "loadingAudio": "Loading audio...",
     "assessmentResults": "Assessment Results",
     "coach": "Coach",
     "learningItems": "Learning items",

--- a/src/i18n/fa.json
+++ b/src/i18n/fa.json
@@ -7,6 +7,7 @@
     "play": "پخش",
     "pauseAudio": "توقف صدا",
     "playAudio": "پخش صدا",
+    "loadingAudio": "در حال بارگذاری صدا...",
     "assessmentResults": "نتایج ارزیابی",
     "coach": "مربی",
     "learningItems": "موارد یادگیری",

--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -272,10 +272,12 @@
       v-if="lesson"
       size="icon"
       @click="togglePlayPause"
+      :disabled="isLoadingAudio"
       class="md:hidden fixed bottom-20 right-6 w-16 h-16 rounded-full shadow-lg text-3xl z-50"
-      :title="isPlaying ? $t('nav.pause') : $t('nav.play')"
-      :aria-label="isPlaying ? $t('nav.pauseAudio') : $t('nav.playAudio')">
-      {{ isPlaying ? '⏸' : '▶️' }}
+      :title="isLoadingAudio ? $t('nav.loading') : (isPlaying ? $t('nav.pause') : $t('nav.play'))"
+      :aria-label="isLoadingAudio ? $t('nav.loadingAudio') : (isPlaying ? $t('nav.pauseAudio') : $t('nav.playAudio'))">
+      <span v-if="isLoadingAudio" class="animate-spin">⏳</span>
+      <span v-else>{{ isPlaying ? '⏸' : '▶️' }}</span>
     </Button>
   </div>
 </template>
@@ -308,7 +310,7 @@ const emit = defineEmits(['update-title'])
 const { loadAllLessonsForWorkshop } = useLessons()
 const { settings } = useSettings()
 const { isItemLearned, toggleItemLearned, areAllItemsLearned, progress } = useProgress()
-const { isPlaying, isPaused, playbackFinished, currentItem, initializeAudio, jumpToExample, cleanup, play, pause } = useAudio()
+const { isLoadingAudio, isPlaying, isPaused, playbackFinished, currentItem, initializeAudio, jumpToExample, cleanup, play, pause } = useAudio()
 const { getAnswer, saveAnswer, validateAnswer } = useAssessments()
 const { setLessonFooter, clearLessonFooter } = useFooter()
 


### PR DESCRIPTION
## Summary
- New `isLoadingAudio` state in `useAudio` composable
- Play button (both mobile FAB and desktop header) shows spinning ⏳ and is disabled during preload
- i18n keys added for all 4 languages (en, de, fa, ar)

## Test plan
- [ ] Load a lesson with audio → play button shows ⏳ until loaded
- [ ] After loading → play button shows ▶️ and works normally
- [ ] Lesson without audio → spinner appears briefly, then normal button