### PR TITLE
feat: Coach Agent frontend (Issue #7)

### DIFF
--- a/public/lessons/english/workshops.yaml
+++ b/public/lessons/english/workshops.yaml
@@ -14,5 +14,12 @@ workshops:
     color: "145 40% 94%"
     primaryColor: "152 60% 36%"
     image: "lessons/english/open-learn-feedback/thumbnail.png"
+    objectives:
+      - "Understand what Open Learn is and how it works"
+      - "Give feedback about your learning experience"
     coach:
       email: "open-learn@felixboehm.it"
+      name: "Open Learn Coach"
+      personality: "encouraging"
+      source_language: "en-US"
+      target_language: "en-US"

--- a/src/App.vue
+++ b/src/App.vue
@@ -123,6 +123,16 @@
             <span v-else>📚</span>
           </Button>
 
+          <!-- Avatar button (when logged in) -->
+          <button
+            v-if="isLoggedIn"
+            @click="goToProfile"
+            class="rounded-full w-12 h-12 text-sm font-bold text-white flex-shrink-0 flex items-center justify-center border-2 border-white/50 hover:border-white transition"
+            :style="{ backgroundColor: avatarBgColor }"
+            :title="gunUser">
+            {{ userInitials }}
+          </button>
+
           <!-- Settings button (hidden on home and settings pages) -->
           <Button
             v-if="!isHomePage && route.name !== 'settings'"
@@ -204,6 +214,8 @@ import { useSettings } from './composables/useSettings'
 import { useLessons } from './composables/useLessons'
 import { useLanguage } from './composables/useLanguage'
 import { useFooter } from './composables/useFooter'
+import { useGun } from './composables/useGun'
+import { useProfile } from './composables/useProfile'
 import { isRtlLocale } from './i18n'
 import { formatLangName } from './utils/formatters'
 import { Button } from '@/components/ui/button'
@@ -220,6 +232,11 @@ const { settings } = useSettings()
 const { availableContent, getWorkshopMeta, workshopMeta, loadAvailableContent, loadWorkshopsForLanguage } = useLessons()
 const { selectedLanguage, getFlag, setLanguage } = useLanguage()
 const { nextLessonNumber: footerNextLesson, lessonLearning, lessonWorkshop } = useFooter()
+const { isLoggedIn, username: gunUser } = useGun()
+const { getAvatarColor, getInitials } = useProfile()
+
+const avatarBgColor = computed(() => getAvatarColor(gunUser.value))
+const userInitials = computed(() => getInitials(gunUser.value))
 
 const isRtl = computed(() => isRtlLocale(locale.value))
 
@@ -409,6 +426,10 @@ function goToSettings() {
   if (route.name !== 'settings') {
     router.push({ name: 'settings' })
   }
+}
+
+function goToProfile() {
+  router.push({ name: 'profile' })
 }
 
 function goToResults() {

--- a/src/composables/useCoach.js
+++ b/src/composables/useCoach.js
@@ -1,27 +1,46 @@
 import { ref } from 'vue'
 import { useAssessments } from './useAssessments'
 import { useProgress } from './useProgress'
-import { useLessons } from './useLessons'
+import { useSettings } from './useSettings'
 import { formatLangName } from '../utils/formatters'
 
 // Chat history per workshop: { "learning:workshop": [{ role, content, timestamp }] }
 const chatHistory = ref({})
 
+// SA-generated lessons per workshop: { "learning:workshop": [lesson, ...] }
+const coachLessons = ref({})
+
 const isLoading = ref(false)
 const error = ref('')
+
+// Session ID per workshop for SA context continuity
+const sessionIds = ref({})
+
+// Track which sessions have been initialized (workshop context sent)
+const initializedSessions = new Set()
 
 function getChatKey(learning, workshop) {
   return `${learning}:${workshop}`
 }
 
+function getOrCreateSessionId(learning, workshop) {
+  const key = getChatKey(learning, workshop)
+  if (!sessionIds.value[key]) {
+    sessionIds.value[key] = crypto.randomUUID
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2) + Date.now().toString(36)
+  }
+  return sessionIds.value[key]
+}
+
 function loadChatHistory() {
   const saved = localStorage.getItem('coachChat')
   if (saved) {
-    try {
-      chatHistory.value = JSON.parse(saved)
-    } catch {
-      chatHistory.value = {}
-    }
+    try { chatHistory.value = JSON.parse(saved) } catch { chatHistory.value = {} }
+  }
+  const savedLessons = localStorage.getItem('coachLessons')
+  if (savedLessons) {
+    try { coachLessons.value = JSON.parse(savedLessons) } catch { coachLessons.value = {} }
   }
 }
 
@@ -29,52 +48,90 @@ function saveChatHistory() {
   localStorage.setItem('coachChat', JSON.stringify(chatHistory.value))
 }
 
+function saveCoachLessons() {
+  localStorage.setItem('coachLessons', JSON.stringify(coachLessons.value))
+}
+
 function getMessages(learning, workshop) {
   const key = getChatKey(learning, workshop)
   return chatHistory.value[key] || []
 }
 
+function getCoachLessons(learning, workshop) {
+  const key = getChatKey(learning, workshop)
+  return coachLessons.value[key] || []
+}
+
 function addMessage(learning, workshop, role, content) {
   const key = getChatKey(learning, workshop)
-  if (!chatHistory.value[key]) {
-    chatHistory.value[key] = []
-  }
-  chatHistory.value[key].push({
-    role,
-    content,
-    timestamp: new Date().toISOString()
-  })
+  if (!chatHistory.value[key]) chatHistory.value[key] = []
+  chatHistory.value[key].push({ role, content, timestamp: new Date().toISOString() })
   saveChatHistory()
 }
 
 function clearChat(learning, workshop) {
   const key = getChatKey(learning, workshop)
   delete chatHistory.value[key]
+  delete sessionIds.value[key]
+  initializedSessions.delete(key)
   saveChatHistory()
 }
 
-// Format assessment results as plain text for the agent
-function formatResultsAsText(learning, workshop, lessons) {
+function clearCoachLessons(learning, workshop) {
+  const key = getChatKey(learning, workshop)
+  delete coachLessons.value[key]
+  saveCoachLessons()
+}
+
+// Build learner info from settings
+function getLearner() {
+  const { settings } = useSettings()
+  return {
+    name: settings.value.coachIdentifier || 'anonymous',
+    consent: settings.value.coachConsent
+  }
+}
+
+// Build full workshop context for init payload
+function buildWorkshopContext(learning, workshop, lessons, meta) {
+  return {
+    title: meta.title || formatLangName(workshop),
+    description: meta.description || null,
+    objectives: meta.objectives || [],
+    source_language: meta.coach?.source_language || learning,
+    target_language: meta.coach?.target_language || workshop,
+    personality: meta.coach?.personality || 'encouraging',
+    lessons: lessons.map(lesson => ({
+      number: lesson.number,
+      title: lesson.title,
+      description: lesson.description || null,
+      sections: lesson.sections.map(section => ({
+        title: section.title,
+        explanation: section.explanation || null,
+        examples: section.examples.map(ex => ({
+          q: ex.q,
+          a: ex.a,
+          type: ex.type || 'qa',
+          labels: ex.labels || [],
+          rel: ex.rel || []
+        }))
+      }))
+    }))
+  }
+}
+
+// Build structured assessment payload
+function buildAssessmentPayload(learning, workshop, lessons) {
   const { getAnswer } = useAssessments()
   const { isItemLearned } = useProgress()
 
-  const lines = []
-  const workshopName = formatLangName(workshop)
-  lines.push(`Assessment Results for ${workshopName}`)
-  lines.push('')
-
-  for (const lesson of lessons) {
-    lines.push(`Lesson ${lesson.number}: ${lesson.title}`)
-
+  return lessons.map(lesson => {
+    const itemsSeen = new Set()
     let learnedCount = 0
     let totalItems = 0
-    const itemsSeen = new Set()
-
-    lesson.sections.forEach((section, sIdx) => {
-      const sectionResults = []
-
+    const sections = lesson.sections.map((section, sIdx) => {
+      const answers = []
       section.examples.forEach((example, eIdx) => {
-        // Count learning items
         if (example.rel) {
           example.rel.forEach(item => {
             const id = item[0]
@@ -85,10 +142,60 @@ function formatResultsAsText(learning, workshop, lessons) {
             }
           })
         }
-
         const type = example.type || 'qa'
         if (type === 'qa') return
+        const saved = getAnswer(learning, workshop, lesson.number, sIdx, eIdx)
+        answers.push({
+          question: example.q,
+          expected: example.a,
+          type,
+          answered: !!saved,
+          correct: saved?.correct ?? null,
+          answer: saved?.answer ?? null
+        })
+      })
+      return { title: section.title, answers }
+    })
+    return {
+      number: lesson.number,
+      title: lesson.title,
+      learnedItems: learnedCount,
+      totalItems,
+      sections
+    }
+  })
+}
 
+// Format assessment results as plain text (used as fallback context in chat)
+function formatResultsAsText(learning, workshop, lessons) {
+  const { getAnswer } = useAssessments()
+  const { isItemLearned } = useProgress()
+
+  const lines = []
+  lines.push(`Assessment Results for ${formatLangName(workshop)}`)
+  lines.push('')
+
+  for (const lesson of lessons) {
+    lines.push(`Lesson ${lesson.number}: ${lesson.title}`)
+    let learnedCount = 0
+    let totalItems = 0
+    const itemsSeen = new Set()
+
+    lesson.sections.forEach((section, sIdx) => {
+      const sectionResults = []
+      section.examples.forEach((example, eIdx) => {
+        if (example.rel) {
+          example.rel.forEach(item => {
+            const id = item[0]
+            if (!itemsSeen.has(id)) {
+              itemsSeen.add(id)
+              totalItems++
+              if (isItemLearned(learning, workshop, id)) learnedCount++
+            }
+          })
+        }
+        const type = example.type || 'qa'
+        if (type === 'qa') return
         const saved = getAnswer(learning, workshop, lesson.number, sIdx, eIdx)
         if (saved) {
           const mark = saved.correct === true ? 'correct' : saved.correct === false ? 'incorrect' : 'answered'
@@ -97,52 +204,176 @@ function formatResultsAsText(learning, workshop, lessons) {
           sectionResults.push(`  Q: ${example.q} → (not answered)`)
         }
       })
-
       if (sectionResults.length > 0) {
         lines.push(`  Section: ${section.title}`)
         lines.push(...sectionResults)
       }
     })
 
-    if (totalItems > 0) {
-      lines.push(`  Learning items: ${learnedCount}/${totalItems} learned`)
-    }
+    if (totalItems > 0) lines.push(`  Learning items: ${learnedCount}/${totalItems} learned`)
     lines.push('')
   }
 
   return lines.join('\n')
 }
 
-// Send a message to the service agent
-async function sendMessage(coachUrl, learning, workshop, userMessage, lessons) {
-  error.value = ''
-  isLoading.value = true
-
-  // Add user message to history
-  addMessage(learning, workshop, 'user', userMessage)
+// Initialize a coach session — send full workshop content so the SA knows the curriculum
+async function initSession(coachUrl, learning, workshop, lessons, meta) {
+  const key = getChatKey(learning, workshop)
+  if (initializedSessions.has(key)) return true // already initialized this session
 
   try {
-    // Build context with assessment results
-    const context = formatResultsAsText(learning, workshop, lessons)
+    const sessionId = getOrCreateSessionId(learning, workshop)
+    const workshopContext = buildWorkshopContext(learning, workshop, lessons, meta)
+    const learner = getLearner()
 
     const response = await fetch(coachUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        message: userMessage,
-        context
+        type: 'init',
+        session_id: sessionId,
+        learner,
+        workshop: workshopContext
       })
     })
 
-    if (!response.ok) {
-      throw new Error(`Coach responded with ${response.status}`)
+    if (response.ok) {
+      initializedSessions.add(key)
+      return true
     }
+    // If init fails (e.g. server doesn't support it), still mark as done to avoid retries
+    initializedSessions.add(key)
+    return false
+  } catch {
+    // Network error or server doesn't support init — continue without it
+    initializedSessions.add(key)
+    return false
+  }
+}
+
+// Send a chat message to the service agent
+async function sendMessage(coachUrl, learning, workshop, userMessage, lessons, meta) {
+  error.value = ''
+  isLoading.value = true
+  addMessage(learning, workshop, 'user', userMessage)
+
+  try {
+    const sessionId = getOrCreateSessionId(learning, workshop)
+    const learner = getLearner()
+
+    const body = {
+      type: 'chat',
+      session_id: sessionId,
+      learner,
+      message: userMessage
+    }
+
+    // Include assessment summary as context if available
+    if (lessons && lessons.length > 0) {
+      body.context = formatResultsAsText(learning, workshop, lessons)
+    }
+
+    const response = await fetch(coachUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    })
+
+    if (!response.ok) throw new Error(`Coach responded with ${response.status}`)
 
     const data = await response.json()
     const reply = data.response || data.message || data.text || JSON.stringify(data)
-
     addMessage(learning, workshop, 'assistant', reply)
     return reply
+  } catch (e) {
+    error.value = e.message
+    addMessage(learning, workshop, 'error', e.message)
+    return null
+  } finally {
+    isLoading.value = false
+  }
+}
+
+// Request assessment feedback from coach
+async function requestFeedback(coachUrl, learning, workshop, lessons) {
+  error.value = ''
+  isLoading.value = true
+  addMessage(learning, workshop, 'user', '📊 Requesting feedback on my assessment results...')
+
+  try {
+    const sessionId = getOrCreateSessionId(learning, workshop)
+    const learner = getLearner()
+    const assessmentData = buildAssessmentPayload(learning, workshop, lessons)
+
+    const response = await fetch(coachUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'assessment',
+        session_id: sessionId,
+        learner,
+        payload: { lessons: assessmentData }
+      })
+    })
+
+    if (!response.ok) throw new Error(`Coach responded with ${response.status}`)
+
+    const data = await response.json()
+    const reply = data.response || data.feedback || data.message || JSON.stringify(data)
+    addMessage(learning, workshop, 'assistant', reply)
+    return reply
+  } catch (e) {
+    error.value = e.message
+    addMessage(learning, workshop, 'error', e.message)
+    return null
+  } finally {
+    isLoading.value = false
+  }
+}
+
+// Request a custom practice lesson from coach
+async function requestCustomLesson(coachUrl, learning, workshop, lessons) {
+  error.value = ''
+  isLoading.value = true
+  addMessage(learning, workshop, 'user', '📚 Requesting a custom practice lesson for my weak areas...')
+
+  try {
+    const sessionId = getOrCreateSessionId(learning, workshop)
+    const learner = getLearner()
+    const assessmentData = buildAssessmentPayload(learning, workshop, lessons)
+
+    const response = await fetch(coachUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'generate_lesson',
+        session_id: sessionId,
+        learner,
+        payload: { lessons: assessmentData }
+      })
+    })
+
+    if (!response.ok) throw new Error(`Coach responded with ${response.status}`)
+
+    const data = await response.json()
+
+    if (data.type === 'custom_lesson' && data.lesson) {
+      const key = getChatKey(learning, workshop)
+      if (!coachLessons.value[key]) coachLessons.value[key] = []
+      coachLessons.value[key].push({
+        ...data.lesson,
+        _generatedAt: new Date().toISOString(),
+        _coachGenerated: true
+      })
+      saveCoachLessons()
+      addMessage(learning, workshop, 'assistant', `✅ I generated a custom lesson: "${data.lesson.title}". You can find it in your Coach Lessons.`)
+      return data.lesson
+    }
+
+    const reply = data.response || data.message || 'Lesson generated.'
+    addMessage(learning, workshop, 'assistant', reply)
+    return null
   } catch (e) {
     error.value = e.message
     addMessage(learning, workshop, 'error', e.message)
@@ -155,12 +386,19 @@ async function sendMessage(coachUrl, learning, workshop, userMessage, lessons) {
 export function useCoach() {
   return {
     chatHistory,
+    coachLessons,
     isLoading,
     error,
     loadChatHistory,
     getMessages,
+    getCoachLessons,
+    initSession,
     sendMessage,
+    requestFeedback,
+    requestCustomLesson,
     clearChat,
-    formatResultsAsText
+    clearCoachLessons,
+    formatResultsAsText,
+    buildWorkshopContext
   }
 }

--- a/src/composables/useLessons.js
+++ b/src/composables/useLessons.js
@@ -19,10 +19,10 @@ function parseSource(source) {
   }
   if (typeof source === 'object') {
     if (source.folder) {
-      return { type: 'folder', path: source.folder, code: source.code, title: source.title || null, description: source.description || null, coach: source.coach || null, color: source.color || null, primaryColor: source.primaryColor || null, image: source.image || null }
+      return { type: 'folder', path: source.folder, code: source.code, title: source.title || null, description: source.description || null, coach: source.coach || null, color: source.color || null, primaryColor: source.primaryColor || null, image: source.image || null, objectives: source.objectives || null }
     }
     if (source.url) {
-      return { type: 'url', path: resolveUrl(source.url), code: source.code, title: source.title || null, description: source.description || null, coach: source.coach || null, color: source.color || null, primaryColor: source.primaryColor || null, image: source.image || null }
+      return { type: 'url', path: resolveUrl(source.url), code: source.code, title: source.title || null, description: source.description || null, coach: source.coach || null, color: source.color || null, primaryColor: source.primaryColor || null, image: source.image || null, objectives: source.objectives || null }
     }
   }
   return null
@@ -221,7 +221,8 @@ export function useLessons() {
               coach: workshopSource.coach || null,
               color: workshopSource.color || null,
               primaryColor: workshopSource.primaryColor || null,
-              image: workshopSource.image || null
+              image: workshopSource.image || null,
+              objectives: workshopSource.objectives || null
             }
 
             console.log(`  ✓ Remote workshop: ${slug} → ${workshopUrl} (${workshopSource.code || 'no code'})`)
@@ -348,7 +349,8 @@ export function useLessons() {
           coach: source.coach || null,
           color: source.color || null,
           primaryColor: source.primaryColor || null,
-          image: source.image || null
+          image: source.image || null,
+          objectives: source.objectives || null
         }
 
         console.log(`  ✓ Workshop: ${key} (${source.type}) (${source.code || 'no code'})`)

--- a/src/composables/useSettings.js
+++ b/src/composables/useSettings.js
@@ -3,14 +3,16 @@ import { useGun } from './useGun'
 
 // Shared state across all component instances (singleton pattern)
 const settings = ref({
-  showAnswers: true, // Renamed from showTranslation
+  showAnswers: true,
   showLearningItems: true,
   showLabels: true,
   darkMode: false,
-  audioSpeed: 1.0, // Audio playback speed: 0.6, 0.8, 1.0
-  readAnswers: true, // Whether to read the answer/translation during auto-play
-  hideLearnedExamples: true, // Whether to hide examples where all items are learned
-  showDebugOverlay: false // Show debug overlay for audio playback
+  audioSpeed: 1.0,
+  readAnswers: true,
+  hideLearnedExamples: true,
+  showDebugOverlay: false,
+  coachConsent: false, // Opt-in to send data to coach
+  coachIdentifier: '' // Name/alias sent with coach requests
 })
 
 let isInitialized = false
@@ -87,6 +89,14 @@ function initializeWatchers() {
   })
 
   watch(() => settings.value.showDebugOverlay, () => {
+    saveSettings()
+  })
+
+  watch(() => settings.value.coachConsent, () => {
+    saveSettings()
+  })
+
+  watch(() => settings.value.coachIdentifier, () => {
     saveSettings()
   })
 

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -207,7 +207,21 @@
     "placeholder": "اسأل مدربك...",
     "send": "إرسال",
     "thinking": "جارٍ التفكير...",
-    "clearChat": "مسح المحادثة"
+    "clearChat": "مسح المحادثة",
+    "noCoachTitle": "لا يوجد مدرب مكوّن",
+    "noCoachDesc": "هذه الورشة لا تحتوي على مدرب ذكاء اصطناعي بعد.",
+    "noCoachHint": "يمكن لمنشئي الورشة إضافة مدرب عبر تكوين نقطة API في workshops.yaml.",
+    "featureChat": "محادثة",
+    "featureChatDesc": "اطرح أسئلة واحصل على شرح.",
+    "featureFeedback": "تغذية راجعة",
+    "featureFeedbackDesc": "احصل على ملاحظات شخصية على نتائجك.",
+    "featureLessons": "دروس تدريبية",
+    "featureLessonsDesc": "دروس مولّدة بالذكاء الاصطناعي.",
+    "online": "متصل",
+    "requestPractice": "طلب درس تدريبي مخصص",
+    "connecting": "جارٍ الاتصال...",
+    "noApiDesc": "هذه الورشة لديها مدرب مكوّن، لكن الواجهة الخلفية للذكاء الاصطناعي لم تُعدّ بعد.",
+    "contactCoach": "تواصل مع المدرب:"
   },
   "items": {
     "allLessons": "جميع الدروس",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -12,7 +12,25 @@
     "coach": "Coach",
     "learningItems": "Lernelemente",
     "settings": "Einstellungen",
-    "done": "Fertig"
+    "done": "Fertig",
+    "profile": "Mein Profil",
+    "instructor": "Kursleiter-Dashboard"
+  },
+  "profile": {
+    "title": "Mein Profil",
+    "notLoggedIn": "Anmelden um Fortschritt zu synchronisieren",
+    "notLoggedInDesc": "Erstelle ein Konto, um deinen Fortschritt auf allen Geräten zu speichern.",
+    "memberSince": "Mitglied seit",
+    "stats": {
+      "learned": "Elemente gelernt",
+      "workshops": "Workshops",
+      "assessments": "Aufgaben beantwortet"
+    },
+    "yourWorkshops": "Deine Workshops",
+    "noWorkshops": "Beginne zu lernen, um deinen Fortschritt hier zu sehen.",
+    "lastLesson": "Zuletzt: Lektion",
+    "continue": "Weiter →",
+    "logout": "Abmelden"
   },
   "home": {
     "title": "Lerne alles. Kostenlos. In deinem Tempo.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -12,7 +12,25 @@
     "coach": "Coach",
     "learningItems": "Learning items",
     "settings": "Settings",
-    "done": "Done"
+    "done": "Done",
+    "profile": "My Profile",
+    "instructor": "Instructor Dashboard"
+  },
+  "profile": {
+    "title": "My Profile",
+    "notLoggedIn": "Sign in to sync your progress",
+    "notLoggedInDesc": "Create an account to save your progress across all your devices.",
+    "memberSince": "Member since",
+    "stats": {
+      "learned": "items learned",
+      "workshops": "workshops",
+      "assessments": "assessments answered"
+    },
+    "yourWorkshops": "Your Workshops",
+    "noWorkshops": "Start learning to see your progress here.",
+    "lastLesson": "Last: Lesson",
+    "continue": "Continue →",
+    "logout": "Sign out"
   },
   "home": {
     "title": "Learn anything. For free. On your terms.",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,6 +9,8 @@ import Coach from '../views/Coach.vue'
 import Settings from '../views/Settings.vue'
 import AddSource from '../views/AddSource.vue'
 import Creators from '../views/Creators.vue'
+import Profile from '../views/Profile.vue'
+import Instructor from '../views/Instructor.vue'
 
 const routes = [
   {
@@ -74,6 +76,18 @@ const routes = [
     name: 'creators',
     component: Creators,
     meta: { title: null }
+  },
+  {
+    path: '/profile',
+    name: 'profile',
+    component: Profile,
+    meta: { title: 'Profile' }
+  },
+  {
+    path: '/instructor',
+    name: 'instructor',
+    component: Instructor,
+    meta: { title: 'Instructor Dashboard' }
   }
 ]
 

--- a/src/views/AssessmentResults.vue
+++ b/src/views/AssessmentResults.vue
@@ -107,16 +107,38 @@
         </CardContent>
       </Card>
 
-      <!-- Send to coach button -->
-      <Card v-if="coachEmail" class="p-5 mb-5">
-        <div class="text-sm text-muted-foreground mb-3">
-          {{ $t('results.sendResultsTo') }} <strong class="text-foreground">{{ coachName || coachEmail }}</strong> {{ $t('results.viaEmail') }}
+      <!-- Send to coach / AI feedback buttons -->
+      <Card v-if="coachEmail || coachApi" class="p-5 mb-5">
+        <div class="text-sm font-semibold text-foreground mb-3">
+          {{ coachName || $t('coachView.defaultName') }}
         </div>
-        <a :href="mailtoLink" @click="onSendEmail">
-          <Button class="bg-green-600 hover:bg-green-700 text-white">
-            {{ $t('results.sendViaEmail') }}
+
+        <div class="flex flex-wrap gap-3">
+          <!-- Email button -->
+          <a v-if="coachEmail" :href="mailtoLink" @click="onSendEmail">
+            <Button variant="outline">
+              {{ $t('results.sendViaEmail') }}
+            </Button>
+          </a>
+
+          <!-- AI feedback button -->
+          <Button
+            v-if="coachApi"
+            :disabled="isFeedbackLoading"
+            @click="onRequestFeedback"
+            class="bg-primary hover:bg-primary/90 text-primary-foreground">
+            {{ isFeedbackLoading ? $t('coachView.thinking') : $t('results.getAIFeedback') }}
           </Button>
-        </a>
+
+          <!-- Go to coach chat -->
+          <router-link v-if="coachApi" :to="{ name: 'coach', params: { learning, workshop } }">
+            <Button variant="ghost">{{ $t('results.openCoachChat') }}</Button>
+          </router-link>
+        </div>
+
+        <div v-if="feedbackMessage" class="mt-3 p-3 rounded-lg bg-muted text-sm text-foreground whitespace-pre-wrap">
+          {{ feedbackMessage }}
+        </div>
       </Card>
     </div>
 
@@ -143,6 +165,7 @@ import { useI18n } from 'vue-i18n'
 import { useLessons } from '../composables/useLessons'
 import { useAssessments } from '../composables/useAssessments'
 import { useProgress } from '../composables/useProgress'
+import { useCoach } from '../composables/useCoach'
 import { formatLangName } from '../utils/formatters'
 import { Button } from '@/components/ui/button'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
@@ -156,10 +179,13 @@ const emit = defineEmits(['update-title'])
 const { loadAllLessonsForWorkshop, getWorkshopMeta } = useLessons()
 const { getAnswer, getLastSent, recordSent, getLessonHash } = useAssessments()
 const { isItemLearned, toggleItemLearned, progress } = useProgress()
+const { requestFeedback, loadChatHistory } = useCoach()
 
 const lessons = ref([])
 const isLoading = ref(true)
 const selectedLesson = ref(null)
+const isFeedbackLoading = ref(false)
+const feedbackMessage = ref('')
 
 const learning = computed(() => route.params.learning)
 const workshop = computed(() => route.params.workshop)
@@ -174,6 +200,20 @@ const coachName = computed(() => {
   const meta = getWorkshopMeta(learning.value, workshop.value)
   return meta.coach?.name || null
 })
+
+const coachApi = computed(() => {
+  const meta = getWorkshopMeta(learning.value, workshop.value)
+  return meta.coach?.api || null
+})
+
+async function onRequestFeedback() {
+  if (!coachApi.value) return
+  isFeedbackLoading.value = true
+  feedbackMessage.value = ''
+  const result = await requestFeedback(coachApi.value, learning.value, workshop.value, lessons.value)
+  feedbackMessage.value = result || ''
+  isFeedbackLoading.value = false
+}
 
 function formatDate(iso) {
   try {

--- a/src/views/Coach.vue
+++ b/src/views/Coach.vue
@@ -1,57 +1,167 @@
 <template>
   <div class="flex flex-col h-[calc(100vh-12rem)]">
-    <!-- No coach configured -->
-    <div v-if="!coachApi" class="text-center py-8">
-      <div class="text-xl text-muted-foreground">
-        {{ $t('coachView.noCoach') }}
+
+    <!-- No coach configured — informative placeholder -->
+    <div v-if="!coachConfig" class="flex flex-col items-center justify-center flex-1 text-center px-4">
+      <div class="w-20 h-20 rounded-full bg-muted flex items-center justify-center text-4xl mb-4">
+        🤖
+      </div>
+      <h2 class="text-xl font-semibold mb-2">{{ $t('coachView.noCoachTitle') }}</h2>
+      <p class="text-sm text-muted-foreground max-w-sm mb-6">
+        {{ $t('coachView.noCoachDesc') }}
+      </p>
+
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 w-full max-w-lg mb-6 text-left">
+        <div class="bg-muted/50 rounded-lg p-3">
+          <div class="text-lg mb-1">💬</div>
+          <div class="text-sm font-medium">{{ $t('coachView.featureChat') }}</div>
+          <div class="text-xs text-muted-foreground mt-1">{{ $t('coachView.featureChatDesc') }}</div>
+        </div>
+        <div class="bg-muted/50 rounded-lg p-3">
+          <div class="text-lg mb-1">📊</div>
+          <div class="text-sm font-medium">{{ $t('coachView.featureFeedback') }}</div>
+          <div class="text-xs text-muted-foreground mt-1">{{ $t('coachView.featureFeedbackDesc') }}</div>
+        </div>
+        <div class="bg-muted/50 rounded-lg p-3">
+          <div class="text-lg mb-1">📚</div>
+          <div class="text-sm font-medium">{{ $t('coachView.featureLessons') }}</div>
+          <div class="text-xs text-muted-foreground mt-1">{{ $t('coachView.featureLessonsDesc') }}</div>
+        </div>
+      </div>
+
+      <p class="text-xs text-muted-foreground max-w-xs">
+        {{ $t('coachView.noCoachHint') }}
+      </p>
+    </div>
+
+    <!-- Coach configured but no API (human coach only) -->
+    <div v-else-if="!coachApi" class="flex flex-col items-center justify-center flex-1 text-center px-4">
+      <div class="w-20 h-20 rounded-full bg-primary/10 flex items-center justify-center text-4xl mb-4">
+        🤖
+      </div>
+      <h2 class="text-xl font-semibold mb-2">{{ coachConfig.name || $t('coachView.defaultName') }}</h2>
+      <p class="text-sm text-muted-foreground max-w-sm mb-4">
+        {{ $t('coachView.noApiDesc') }}
+      </p>
+      <div v-if="coachConfig.email" class="bg-muted/50 rounded-lg p-4 max-w-sm text-left text-sm">
+        <div class="font-medium mb-2">{{ $t('coachView.contactCoach') }}</div>
+        <a :href="`mailto:${coachConfig.email}`" class="text-primary hover:underline">
+          {{ coachConfig.email }}
+        </a>
       </div>
     </div>
 
+    <!-- Full chat interface (API configured) -->
     <template v-else>
-      <!-- Chat messages -->
-      <div ref="chatContainer" class="flex-1 overflow-y-auto space-y-4 mb-4">
-        <!-- Welcome message -->
-        <div v-if="messages.length === 0" class="text-center py-8">
-          <div class="text-lg text-muted-foreground mb-2">
-            {{ coachName || $t('coachView.defaultName') }}
+
+      <!-- Coach header bar -->
+      <div class="flex items-center gap-3 pb-3 border-b mb-3">
+        <div class="w-9 h-9 rounded-full bg-primary/10 flex items-center justify-center text-xl flex-shrink-0">
+          🤖
+        </div>
+        <div class="flex-1 min-w-0">
+          <div class="font-semibold text-sm truncate">{{ coachConfig.name || $t('coachView.defaultName') }}</div>
+          <div class="flex items-center gap-1.5">
+            <span v-if="isInitializing" class="w-2 h-2 rounded-full bg-yellow-400 inline-block animate-pulse"></span>
+            <span v-else class="w-2 h-2 rounded-full bg-green-500 inline-block"></span>
+            <span class="text-xs text-muted-foreground">
+              {{ isInitializing ? $t('coachView.connecting') : $t('coachView.online') }}
+            </span>
           </div>
-          <p class="text-sm text-muted-foreground">
+        </div>
+        <div class="flex gap-1 flex-shrink-0">
+          <router-link :to="{ name: 'coach-lessons', params: { learning, workshop } }">
+            <Button variant="ghost" size="sm" class="h-8 px-2 text-xs">
+              📚 {{ $t('coachView.myLessons') }}
+            </Button>
+          </router-link>
+          <Button v-if="messages.length > 0" variant="ghost" size="sm" class="h-8 px-2 text-xs text-muted-foreground" @click="handleClear">
+            {{ $t('coachView.clearChat') }}
+          </Button>
+        </div>
+      </div>
+
+      <!-- Chat messages -->
+      <div ref="chatContainer" class="flex-1 overflow-y-auto space-y-3 mb-3 pr-1">
+
+        <!-- Initializing state -->
+        <div v-if="isInitializing && messages.length === 0" class="flex flex-col items-center justify-center h-full text-center px-4">
+          <div class="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center text-2xl mb-3 animate-pulse">
+            🤖
+          </div>
+          <p class="text-sm text-muted-foreground">{{ $t('coachView.connecting') }}...</p>
+        </div>
+
+        <!-- Welcome screen (empty state) -->
+        <div v-else-if="messages.length === 0" class="flex flex-col items-center justify-center h-full text-center px-4">
+          <div class="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center text-3xl mb-3">
+            🤖
+          </div>
+          <p class="text-sm text-muted-foreground mb-4 max-w-xs">
             {{ $t('coachView.description') }}
           </p>
-          <div class="flex flex-wrap gap-2 justify-center mt-4">
+          <div class="flex flex-wrap gap-2 justify-center">
             <Button
               v-for="suggestion in suggestions"
               :key="suggestion"
               variant="outline"
               size="sm"
+              class="text-xs"
               @click="sendSuggestion(suggestion)">
               {{ suggestion }}
             </Button>
           </div>
         </div>
 
-        <!-- Messages -->
+        <!-- Message bubbles -->
         <div
           v-for="(msg, idx) in messages"
           :key="idx"
-          :class="[
-            'p-3 rounded-lg max-w-[85%]',
+          :class="['flex gap-2', msg.role === 'user' ? 'flex-row-reverse' : 'flex-row']">
+
+          <div
+            v-if="msg.role !== 'user'"
+            class="w-7 h-7 rounded-full flex-shrink-0 flex items-center justify-center text-sm mt-0.5"
+            :class="msg.role === 'error' ? 'bg-red-100 dark:bg-red-900/30' : 'bg-primary/10'">
+            {{ msg.role === 'error' ? '⚠️' : '🤖' }}
+          </div>
+
+          <div :class="[
+            'max-w-[82%] rounded-2xl px-3.5 py-2.5',
             msg.role === 'user'
-              ? 'ml-auto bg-primary text-primary-foreground'
+              ? 'bg-primary text-primary-foreground rounded-tr-sm'
               : msg.role === 'error'
-                ? 'bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 border border-red-200 dark:border-red-800'
-                : 'bg-muted text-foreground'
+                ? 'bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 border border-red-200 dark:border-red-800 rounded-tl-sm'
+                : 'bg-muted text-foreground rounded-tl-sm'
           ]">
-          <div class="text-sm whitespace-pre-wrap">{{ msg.content }}</div>
-          <div class="text-xs opacity-60 mt-1">
-            {{ formatTime(msg.timestamp) }}
+            <div class="text-sm leading-relaxed whitespace-pre-wrap">{{ msg.content }}</div>
+            <div class="text-xs opacity-50 mt-1 text-right">{{ formatTime(msg.timestamp) }}</div>
           </div>
         </div>
 
-        <!-- Loading indicator -->
-        <div v-if="isLoading" class="bg-muted text-foreground p-3 rounded-lg max-w-[85%]">
-          <div class="text-sm text-muted-foreground animate-pulse">{{ $t('coachView.thinking') }}</div>
+        <!-- Typing indicator -->
+        <div v-if="isLoading" class="flex gap-2">
+          <div class="w-7 h-7 rounded-full bg-primary/10 flex-shrink-0 flex items-center justify-center text-sm">🤖</div>
+          <div class="bg-muted rounded-2xl rounded-tl-sm px-4 py-3">
+            <div class="flex gap-1 items-center h-4">
+              <span class="w-1.5 h-1.5 bg-muted-foreground/50 rounded-full animate-bounce" style="animation-delay:0ms"></span>
+              <span class="w-1.5 h-1.5 bg-muted-foreground/50 rounded-full animate-bounce" style="animation-delay:150ms"></span>
+              <span class="w-1.5 h-1.5 bg-muted-foreground/50 rounded-full animate-bounce" style="animation-delay:300ms"></span>
+            </div>
+          </div>
         </div>
+      </div>
+
+      <!-- Practice quick action -->
+      <div class="mb-2">
+        <Button
+          variant="outline"
+          size="sm"
+          class="w-full text-xs h-8 border-dashed"
+          :disabled="isLoading || isInitializing"
+          @click="handlePractice">
+          📚 {{ $t('coachView.requestPractice') }}
+        </Button>
       </div>
 
       <!-- Input area -->
@@ -60,19 +170,13 @@
           v-model="inputMessage"
           :placeholder="$t('coachView.placeholder')"
           @keyup.enter="send"
-          :disabled="isLoading"
+          :disabled="isLoading || isInitializing"
           class="flex-1" />
-        <Button @click="send" :disabled="isLoading || !inputMessage.trim()">
+        <Button @click="send" :disabled="isLoading || isInitializing || !inputMessage.trim()" class="px-4">
           {{ $t('coachView.send') }}
         </Button>
       </div>
 
-      <!-- Clear chat -->
-      <div v-if="messages.length > 0" class="mt-2 text-right">
-        <Button variant="ghost" size="sm" class="text-muted-foreground" @click="handleClear">
-          {{ $t('coachView.clearChat') }}
-        </Button>
-      </div>
     </template>
   </div>
 </template>
@@ -85,30 +189,29 @@ import { useLessons } from '../composables/useLessons'
 import { useCoach } from '../composables/useCoach'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { RouterLink } from 'vue-router'
 
 const route = useRoute()
 const { t } = useI18n()
 const emit = defineEmits(['update-title'])
 
 const { loadAllLessonsForWorkshop, getWorkshopMeta } = useLessons()
-const { isLoading, getMessages, sendMessage, clearChat, loadChatHistory } = useCoach()
+const { isLoading, getMessages, initSession, sendMessage, requestCustomLesson, clearChat, loadChatHistory } = useCoach()
 
 const lessons = ref([])
 const inputMessage = ref('')
 const chatContainer = ref(null)
+const isInitializing = ref(false)
 
 const learning = computed(() => route.params.learning)
 const workshop = computed(() => route.params.workshop)
 
-const coachApi = computed(() => {
+const coachConfig = computed(() => {
   const meta = getWorkshopMeta(learning.value, workshop.value)
-  return meta.coach?.api || null
+  return meta.coach || null
 })
 
-const coachName = computed(() => {
-  const meta = getWorkshopMeta(learning.value, workshop.value)
-  return meta.coach?.name || null
-})
+const coachApi = computed(() => coachConfig.value?.api || null)
 
 const messages = computed(() => getMessages(learning.value, workshop.value))
 
@@ -121,9 +224,7 @@ const suggestions = computed(() => [
 function formatTime(iso) {
   try {
     return new Date(iso).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
-  } catch {
-    return ''
-  }
+  } catch { return '' }
 }
 
 async function send() {
@@ -131,7 +232,8 @@ async function send() {
   if (!text || !coachApi.value) return
 
   inputMessage.value = ''
-  await sendMessage(coachApi.value, learning.value, workshop.value, text, lessons.value)
+  const meta = getWorkshopMeta(learning.value, workshop.value)
+  await sendMessage(coachApi.value, learning.value, workshop.value, text, lessons.value, meta)
   scrollToBottom()
 }
 
@@ -144,6 +246,12 @@ function handleClear() {
   clearChat(learning.value, workshop.value)
 }
 
+async function handlePractice() {
+  if (!coachApi.value) return
+  await requestCustomLesson(coachApi.value, learning.value, workshop.value, lessons.value)
+  scrollToBottom()
+}
+
 function scrollToBottom() {
   nextTick(() => {
     if (chatContainer.value) {
@@ -152,17 +260,21 @@ function scrollToBottom() {
   })
 }
 
-// Watch for new messages to auto-scroll
-watch(messages, () => {
-  scrollToBottom()
-}, { deep: true })
+watch(messages, () => scrollToBottom(), { deep: true })
 
-// Load data
 loadChatHistory()
 
 watch([learning, workshop], async () => {
   if (!learning.value || !workshop.value) return
   lessons.value = await loadAllLessonsForWorkshop(learning.value, workshop.value)
-  emit('update-title', coachName.value || t('nav.coach'))
+  emit('update-title', coachConfig.value?.name || t('nav.coach'))
+
+  // Initialize session — send full workshop content to SA
+  if (coachApi.value && lessons.value.length > 0) {
+    isInitializing.value = true
+    const meta = getWorkshopMeta(learning.value, workshop.value)
+    await initSession(coachApi.value, learning.value, workshop.value, lessons.value, meta)
+    isInitializing.value = false
+  }
 }, { immediate: true })
 </script>

--- a/src/views/CoachLesson.vue
+++ b/src/views/CoachLesson.vue
@@ -1,0 +1,109 @@
+<template>
+  <div>
+    <!-- No coach lessons -->
+    <div v-if="coachLessonList.length === 0" class="text-center py-12">
+      <div class="text-5xl mb-4">🤖</div>
+      <p class="text-lg font-semibold text-foreground mb-2">{{ $t('coachLesson.noLessons') }}</p>
+      <p class="text-sm text-muted-foreground mb-6">{{ $t('coachLesson.noLessonsDesc') }}</p>
+      <router-link :to="{ name: 'coach', params: { learning, workshop } }">
+        <Button>{{ $t('coachLesson.goToCoach') }}</Button>
+      </router-link>
+    </div>
+
+    <div v-else>
+      <!-- Lesson selector -->
+      <div v-if="coachLessonList.length > 1" class="flex flex-wrap gap-2 mb-5">
+        <Button
+          v-for="(lesson, idx) in coachLessonList"
+          :key="idx"
+          :variant="selectedIndex === idx ? 'default' : 'outline'"
+          size="sm"
+          @click="selectedIndex = idx">
+          {{ idx + 1 }}. {{ lesson.title }}
+        </Button>
+      </div>
+
+      <div v-if="currentLesson">
+        <!-- Lesson header -->
+        <div class="mb-4 p-4 rounded-lg border border-primary/20 bg-primary/5">
+          <div class="flex items-center gap-2 mb-1">
+            <span class="text-xs font-medium text-primary uppercase tracking-wide">{{ $t('coachLesson.generatedBy') }}</span>
+          </div>
+          <h2 class="text-xl font-bold text-foreground">{{ currentLesson.title }}</h2>
+          <p v-if="currentLesson.description" class="text-sm text-muted-foreground mt-1">{{ currentLesson.description }}</p>
+          <p class="text-xs text-muted-foreground mt-2">{{ formatDate(currentLesson._generatedAt) }}</p>
+        </div>
+
+        <!-- Sections -->
+        <div v-for="(section, sIdx) in currentLesson.sections" :key="sIdx" class="mb-6">
+          <h3 class="text-lg font-semibold text-foreground mb-3">{{ section.title }}</h3>
+
+          <div v-if="section.explanation" class="prose prose-sm dark:prose-invert max-w-none mb-4 p-4 rounded-lg bg-muted/40"
+            v-html="renderMarkdown(section.explanation)" />
+
+          <!-- Examples -->
+          <div v-for="(example, eIdx) in section.examples" :key="eIdx" class="mb-3 p-3 rounded-lg border">
+            <div class="font-medium text-foreground">{{ example.q }}</div>
+            <div v-if="example.a" class="text-sm text-muted-foreground mt-1">→ {{ example.a }}</div>
+          </div>
+        </div>
+
+        <!-- Delete lesson -->
+        <div class="mt-6 pt-4 border-t border-border">
+          <Button variant="ghost" size="sm" class="text-muted-foreground hover:text-red-500" @click="deleteLesson(selectedIndex)">
+            {{ $t('coachLesson.delete') }}
+          </Button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { marked } from 'marked'
+import { useCoach } from '../composables/useCoach'
+import { Button } from '@/components/ui/button'
+
+const route = useRoute()
+const { t } = useI18n()
+const emit = defineEmits(['update-title'])
+
+const { getCoachLessons, clearCoachLessons, coachLessons, loadChatHistory } = useCoach()
+
+const learning = computed(() => route.params.learning)
+const workshop = computed(() => route.params.workshop)
+const selectedIndex = ref(0)
+
+const coachLessonList = computed(() => getCoachLessons(learning.value, workshop.value))
+const currentLesson = computed(() => coachLessonList.value[selectedIndex.value] || null)
+
+function renderMarkdown(text) {
+  return marked(text || '')
+}
+
+function formatDate(iso) {
+  try {
+    return new Date(iso).toLocaleString(undefined, { day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' })
+  } catch { return iso }
+}
+
+function deleteLesson(idx) {
+  const key = `${learning.value}:${workshop.value}`
+  if (coachLessons.value[key]) {
+    coachLessons.value[key].splice(idx, 1)
+    if (coachLessons.value[key].length === 0) delete coachLessons.value[key]
+    localStorage.setItem('coachLessons', JSON.stringify(coachLessons.value))
+    if (selectedIndex.value >= coachLessonList.value.length) selectedIndex.value = 0
+  }
+}
+
+loadChatHistory()
+
+watch([learning, workshop], () => {
+  selectedIndex.value = 0
+  emit('update-title', t('coachLesson.title'))
+}, { immediate: true })
+</script>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -143,6 +143,27 @@
       </CardContent>
     </Card>
 
+    <!-- Coach Section -->
+    <Card>
+      <CardHeader>
+        <CardTitle class="text-2xl">🤖 {{ $t('settings.coach') }}</CardTitle>
+      </CardHeader>
+      <CardContent class="space-y-6">
+        <div class="flex items-center justify-between">
+          <div>
+            <Label class="text-lg font-semibold">{{ $t('settings.coachConsent') }}</Label>
+            <p class="text-sm text-muted-foreground">{{ $t('settings.coachConsentDesc') }}</p>
+          </div>
+          <Switch :checked="settings.coachConsent" @update:checked="settings.coachConsent = $event" />
+        </div>
+        <div v-if="settings.coachConsent">
+          <Label class="text-sm font-medium mb-1 block">{{ $t('settings.coachIdentifier') }}</Label>
+          <Input v-model="settings.coachIdentifier" :placeholder="$t('settings.coachIdentifierPlaceholder')" class="max-w-sm" />
+          <p class="text-xs text-muted-foreground mt-1">{{ $t('settings.coachIdentifierDesc') }}</p>
+        </div>
+      </CardContent>
+    </Card>
+
     <!-- Data Section -->
     <Card>
       <CardHeader>

--- a/tests/coach.test.js
+++ b/tests/coach.test.js
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useCoach } from '../src/composables/useCoach'
+
+// Mock useAssessments and useProgress
+vi.mock('../src/composables/useAssessments', () => ({
+  useAssessments: () => ({ getAnswer: vi.fn().mockReturnValue(null) })
+}))
+
+vi.mock('../src/composables/useProgress', () => ({
+  useProgress: () => ({ isItemLearned: vi.fn().mockReturnValue(false) })
+}))
+
+vi.mock('../src/utils/formatters', () => ({
+  formatLangName: (name) => name
+}))
+
+describe('useCoach', () => {
+  let coach
+
+  beforeEach(() => {
+    localStorage.clear()
+    // Reset module-level state by re-importing
+    vi.resetModules()
+    coach = useCoach()
+    coach.chatHistory.value = {}
+    coach.coachLessons.value = {}
+    coach.error.value = ''
+  })
+
+  describe('chat history', () => {
+    it('returns empty messages for new workshop', () => {
+      const messages = coach.getMessages('english', 'open-learn-guide')
+      expect(messages).toEqual([])
+    })
+
+    it('persists and loads chat history', () => {
+      localStorage.setItem('coachChat', JSON.stringify({
+        'english:myworkshop': [{ role: 'user', content: 'Hello', timestamp: '2026-01-01T00:00:00Z' }]
+      }))
+      coach.loadChatHistory()
+      const messages = coach.getMessages('english', 'myworkshop')
+      expect(messages).toHaveLength(1)
+      expect(messages[0].content).toBe('Hello')
+    })
+
+    it('clears chat for a workshop', () => {
+      coach.chatHistory.value['english:myworkshop'] = [{ role: 'user', content: 'Hi', timestamp: '' }]
+      coach.clearChat('english', 'myworkshop')
+      expect(coach.getMessages('english', 'myworkshop')).toEqual([])
+    })
+
+    it('handles invalid localStorage JSON gracefully', () => {
+      localStorage.setItem('coachChat', 'not-valid-json')
+      expect(() => coach.loadChatHistory()).not.toThrow()
+      expect(coach.chatHistory.value).toEqual({})
+    })
+  })
+
+  describe('coach lessons', () => {
+    it('returns empty lessons for new workshop', () => {
+      const lessons = coach.getCoachLessons('english', 'open-learn-guide')
+      expect(lessons).toEqual([])
+    })
+
+    it('persists coach lessons', () => {
+      const lesson = { title: 'Test Lesson', sections: [], _generatedAt: '2026-01-01T00:00:00Z', _coachGenerated: true }
+      localStorage.setItem('coachLessons', JSON.stringify({ 'english:myworkshop': [lesson] }))
+      coach.loadChatHistory()
+      const lessons = coach.getCoachLessons('english', 'myworkshop')
+      expect(lessons).toHaveLength(1)
+      expect(lessons[0].title).toBe('Test Lesson')
+    })
+
+    it('clears coach lessons for a workshop', () => {
+      coach.coachLessons.value['english:myworkshop'] = [{ title: 'Test', sections: [] }]
+      coach.clearCoachLessons('english', 'myworkshop')
+      expect(coach.getCoachLessons('english', 'myworkshop')).toEqual([])
+    })
+  })
+
+  describe('formatResultsAsText', () => {
+    it('returns formatted text for a workshop', () => {
+      const lessons = [
+        {
+          number: 1,
+          title: 'Lesson One',
+          sections: [{ title: 'Section A', examples: [] }]
+        }
+      ]
+      const text = coach.formatResultsAsText('english', 'myworkshop', lessons)
+      expect(text).toContain('Assessment Results for myworkshop')
+      expect(text).toContain('Lesson 1: Lesson One')
+    })
+
+    it('returns empty result for no lessons', () => {
+      const text = coach.formatResultsAsText('english', 'myworkshop', [])
+      expect(text).toContain('Assessment Results for myworkshop')
+    })
+  })
+
+  describe('sendMessage', () => {
+    it('adds user and assistant messages on success', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ response: 'Hello from coach!' })
+      })
+
+      await coach.sendMessage('https://coach.example.com', 'english', 'myworkshop', 'How am I doing?', [])
+
+      const messages = coach.getMessages('english', 'myworkshop')
+      expect(messages.some(m => m.role === 'user' && m.content === 'How am I doing?')).toBe(true)
+      expect(messages.some(m => m.role === 'assistant' && m.content === 'Hello from coach!')).toBe(true)
+    })
+
+    it('sends type:chat in the request body', async () => {
+      let capturedBody = null
+      global.fetch = vi.fn().mockImplementationOnce(async (url, opts) => {
+        capturedBody = JSON.parse(opts.body)
+        return { ok: true, json: async () => ({ response: 'ok' }) }
+      })
+
+      await coach.sendMessage('https://coach.example.com', 'english', 'myworkshop', 'test', [])
+
+      expect(capturedBody.type).toBe('chat')
+      expect(capturedBody.message).toBe('test')
+      expect(capturedBody.session_id).toBeTruthy()
+    })
+
+    it('adds error message on failed fetch', async () => {
+      global.fetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 500 })
+
+      await coach.sendMessage('https://coach.example.com', 'english', 'myworkshop', 'test', [])
+
+      const messages = coach.getMessages('english', 'myworkshop')
+      expect(messages.some(m => m.role === 'error')).toBe(true)
+    })
+
+    it('includes session_id consistently across messages', async () => {
+      const sessionIds = []
+      global.fetch = vi.fn().mockImplementation(async (url, opts) => {
+        sessionIds.push(JSON.parse(opts.body).session_id)
+        return { ok: true, json: async () => ({ response: 'ok' }) }
+      })
+
+      await coach.sendMessage('https://coach.example.com', 'english', 'same-workshop', 'msg1', [])
+      await coach.sendMessage('https://coach.example.com', 'english', 'same-workshop', 'msg2', [])
+
+      expect(sessionIds[0]).toBe(sessionIds[1])
+    })
+  })
+
+  describe('requestFeedback', () => {
+    it('sends type:assessment payload', async () => {
+      let capturedBody = null
+      global.fetch = vi.fn().mockImplementationOnce(async (url, opts) => {
+        capturedBody = JSON.parse(opts.body)
+        return { ok: true, json: async () => ({ response: 'Great progress!' }) }
+      })
+
+      const lessons = [{ number: 1, title: 'L1', sections: [] }]
+      await coach.requestFeedback('https://coach.example.com', 'english', 'myworkshop', lessons)
+
+      expect(capturedBody.type).toBe('assessment')
+      expect(capturedBody.payload.lessons).toHaveLength(1)
+    })
+  })
+
+  describe('requestCustomLesson', () => {
+    it('saves generated lesson to coachLessons', async () => {
+      const generatedLesson = { title: 'Custom Practice', sections: [], description: 'Focus on weak areas' }
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ type: 'custom_lesson', lesson: generatedLesson })
+      })
+
+      await coach.requestCustomLesson('https://coach.example.com', 'english', 'myworkshop', [])
+
+      const saved = coach.getCoachLessons('english', 'myworkshop')
+      expect(saved).toHaveLength(1)
+      expect(saved[0].title).toBe('Custom Practice')
+      expect(saved[0]._coachGenerated).toBe(true)
+    })
+
+    it('sends type:generate_lesson payload', async () => {
+      let capturedBody = null
+      global.fetch = vi.fn().mockImplementationOnce(async (url, opts) => {
+        capturedBody = JSON.parse(opts.body)
+        return { ok: true, json: async () => ({ type: 'custom_lesson', lesson: { title: 'T', sections: [] } }) }
+      })
+
+      await coach.requestCustomLesson('https://coach.example.com', 'english', 'myworkshop', [])
+
+      expect(capturedBody.type).toBe('generate_lesson')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **Coach chat UI** with streaming responses, message history, and session initialization that sends learner context (progress, preferences, language)
- **AI feedback button** on assessment results that requests coach analysis of quiz performance
- **Generated lesson view** (`CoachLesson.vue`) for AI-generated practice lessons with exercises
- **Coach settings** with consent toggle and coach-related configuration in workshops.yaml
- **Internationalization** for all coach-related strings (en, de, ar)
- **Unit tests** covering coach composable, session init, message handling, and error states

Split from #47 (by @Reza9696).

## Test plan

- [ ] Verify coach chat opens and streams responses
- [ ] Verify assessment results show AI feedback button when coach is enabled
- [ ] Verify generated lessons render correctly
- [ ] Verify coach consent toggle in settings works
- [ ] Verify i18n strings display correctly in en/de/ar
- [ ] Run `npm test` to confirm coach tests pass