### PR TITLE
feat: user profile and instructor dashboard (Issue #48)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -123,6 +123,16 @@
             <span v-else>📚</span>
           </Button>
 
+          <!-- Avatar button (when logged in) -->
+          <button
+            v-if="isLoggedIn"
+            @click="goToProfile"
+            class="rounded-full w-12 h-12 text-sm font-bold text-white flex-shrink-0 flex items-center justify-center border-2 border-white/50 hover:border-white transition"
+            :style="{ backgroundColor: avatarBgColor }"
+            :title="gunUser">
+            {{ userInitials }}
+          </button>
+
           <!-- Settings button (hidden on home and settings pages) -->
           <Button
             v-if="!isHomePage && route.name !== 'settings'"
@@ -204,6 +214,8 @@ import { useSettings } from './composables/useSettings'
 import { useLessons } from './composables/useLessons'
 import { useLanguage } from './composables/useLanguage'
 import { useFooter } from './composables/useFooter'
+import { useGun } from './composables/useGun'
+import { useProfile } from './composables/useProfile'
 import { isRtlLocale } from './i18n'
 import { formatLangName } from './utils/formatters'
 import { Button } from '@/components/ui/button'
@@ -220,6 +232,11 @@ const { settings } = useSettings()
 const { availableContent, getWorkshopMeta, workshopMeta, loadAvailableContent, loadWorkshopsForLanguage } = useLessons()
 const { selectedLanguage, getFlag, setLanguage } = useLanguage()
 const { nextLessonNumber: footerNextLesson, lessonLearning, lessonWorkshop } = useFooter()
+const { isLoggedIn, username: gunUser } = useGun()
+const { getAvatarColor, getInitials } = useProfile()
+
+const avatarBgColor = computed(() => getAvatarColor(gunUser.value))
+const userInitials = computed(() => getInitials(gunUser.value))
 
 const isRtl = computed(() => isRtlLocale(locale.value))
 
@@ -409,6 +426,10 @@ function goToSettings() {
   if (route.name !== 'settings') {
     router.push({ name: 'settings' })
   }
+}
+
+function goToProfile() {
+  router.push({ name: 'profile' })
 }
 
 function goToResults() {

--- a/src/composables/useProfile.js
+++ b/src/composables/useProfile.js
@@ -1,0 +1,115 @@
+import { ref } from 'vue'
+
+// Module-level singleton state
+const lastVisited = ref({})
+
+// Generate a deterministic HSL color from username char codes
+function getAvatarColor(username) {
+  if (!username) return 'hsl(228, 60%, 55%)'
+  let sum = 0
+  for (let i = 0; i < username.length; i++) {
+    sum += username.charCodeAt(i)
+  }
+  const hue = sum % 360
+  return `hsl(${hue}, 60%, 55%)`
+}
+
+// Get 1-2 uppercase initials from username
+function getInitials(username) {
+  if (!username) return '?'
+  const trimmed = username.trim()
+  if (!trimmed) return '?'
+  const parts = trimmed.split(/\s+/)
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[1][0]).toUpperCase()
+  }
+  return trimmed.slice(0, 2).toUpperCase()
+}
+
+// Save last visited lesson to localStorage
+function trackLastLesson(learning, workshop, lessonNumber) {
+  const key = `${learning}:${workshop}`
+  lastVisited.value[key] = {
+    lessonNumber,
+    timestamp: Date.now()
+  }
+  try {
+    localStorage.setItem('lastVisited', JSON.stringify(lastVisited.value))
+  } catch (e) {
+    console.error('Error saving lastVisited:', e)
+  }
+}
+
+// Get last visited lesson for a workshop
+function getLastLesson(learning, workshop) {
+  const key = `${learning}:${workshop}`
+  return lastVisited.value[key] || null
+}
+
+// Load lastVisited from localStorage
+function loadLastVisited() {
+  try {
+    const saved = localStorage.getItem('lastVisited')
+    if (saved) {
+      lastVisited.value = JSON.parse(saved)
+    }
+  } catch (e) {
+    console.error('Error loading lastVisited:', e)
+    lastVisited.value = {}
+  }
+}
+
+// Get active workshops from progress object, sorted by most items learned
+function getActiveWorkshops(progress) {
+  if (!progress) return []
+  return Object.keys(progress)
+    .map(key => {
+      const parts = key.split(':')
+      if (parts.length < 2) return null
+      const learning = parts[0]
+      const workshop = parts.slice(1).join(':')
+      const learnedCount = Object.keys(progress[key] || {}).length
+      return { learning, workshop, learnedCount }
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.learnedCount - a.learnedCount)
+}
+
+// Get overall user stats from progress and assessments
+function getUserStats(progress, assessments) {
+  let totalLearned = 0
+  let workshopCount = 0
+  let totalAssessments = 0
+
+  if (progress) {
+    const keys = Object.keys(progress)
+    workshopCount = keys.length
+    for (const key of keys) {
+      totalLearned += Object.keys(progress[key] || {}).length
+    }
+  }
+
+  if (assessments) {
+    for (const lessonKey of Object.keys(assessments)) {
+      const lessonAnswers = assessments[lessonKey]
+      if (lessonAnswers) {
+        totalAssessments += Object.keys(lessonAnswers).length
+      }
+    }
+  }
+
+  return { totalLearned, totalAssessments, workshopCount }
+}
+
+export function useProfile() {
+  return {
+    lastVisited,
+    getAvatarColor,
+    getInitials,
+    trackLastLesson,
+    getLastLesson,
+    loadLastVisited,
+    getActiveWorkshops,
+    getUserStats
+  }
+}

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -12,7 +12,25 @@
     "coach": "Coach",
     "learningItems": "Lernelemente",
     "settings": "Einstellungen",
-    "done": "Fertig"
+    "done": "Fertig",
+    "profile": "Mein Profil",
+    "instructor": "Kursleiter-Dashboard"
+  },
+  "profile": {
+    "title": "Mein Profil",
+    "notLoggedIn": "Anmelden um Fortschritt zu synchronisieren",
+    "notLoggedInDesc": "Erstelle ein Konto, um deinen Fortschritt auf allen Geräten zu speichern.",
+    "memberSince": "Mitglied seit",
+    "stats": {
+      "learned": "Elemente gelernt",
+      "workshops": "Workshops",
+      "assessments": "Aufgaben beantwortet"
+    },
+    "yourWorkshops": "Deine Workshops",
+    "noWorkshops": "Beginne zu lernen, um deinen Fortschritt hier zu sehen.",
+    "lastLesson": "Zuletzt: Lektion",
+    "continue": "Weiter →",
+    "logout": "Abmelden"
   },
   "home": {
     "title": "Lerne alles. Kostenlos. In deinem Tempo.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -12,7 +12,25 @@
     "coach": "Coach",
     "learningItems": "Learning items",
     "settings": "Settings",
-    "done": "Done"
+    "done": "Done",
+    "profile": "My Profile",
+    "instructor": "Instructor Dashboard"
+  },
+  "profile": {
+    "title": "My Profile",
+    "notLoggedIn": "Sign in to sync your progress",
+    "notLoggedInDesc": "Create an account to save your progress across all your devices.",
+    "memberSince": "Member since",
+    "stats": {
+      "learned": "items learned",
+      "workshops": "workshops",
+      "assessments": "assessments answered"
+    },
+    "yourWorkshops": "Your Workshops",
+    "noWorkshops": "Start learning to see your progress here.",
+    "lastLesson": "Last: Lesson",
+    "continue": "Continue →",
+    "logout": "Sign out"
   },
   "home": {
     "title": "Learn anything. For free. On your terms.",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,6 +9,8 @@ import Coach from '../views/Coach.vue'
 import Settings from '../views/Settings.vue'
 import AddSource from '../views/AddSource.vue'
 import Creators from '../views/Creators.vue'
+import Profile from '../views/Profile.vue'
+import Instructor from '../views/Instructor.vue'
 
 const routes = [
   {
@@ -74,6 +76,18 @@ const routes = [
     name: 'creators',
     component: Creators,
     meta: { title: null }
+  },
+  {
+    path: '/profile',
+    name: 'profile',
+    component: Profile,
+    meta: { title: 'Profile' }
+  },
+  {
+    path: '/instructor',
+    name: 'instructor',
+    component: Instructor,
+    meta: { title: 'Instructor Dashboard' }
   }
 ]
 

--- a/src/views/Instructor.vue
+++ b/src/views/Instructor.vue
@@ -1,0 +1,133 @@
+<template>
+  <div class="space-y-8">
+    <!-- Not logged in -->
+    <template v-if="!isLoggedIn">
+      <Card>
+        <CardContent class="py-12 text-center space-y-4">
+          <div class="text-4xl">🔒</div>
+          <p class="text-muted-foreground">Please sign in first to access the Instructor Dashboard.</p>
+          <Button @click="goToProfile">Sign In</Button>
+        </CardContent>
+      </Card>
+    </template>
+
+    <!-- Logged in -->
+    <template v-else>
+      <!-- Header -->
+      <div>
+        <h2 class="text-3xl font-bold">Instructor Dashboard</h2>
+        <p class="text-muted-foreground mt-1">Share your workshops with learners</p>
+      </div>
+
+      <!-- My Workshops -->
+      <Card>
+        <CardHeader>
+          <CardTitle class="text-xl">My Workshops</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <template v-if="userSources.length > 0">
+            <div class="space-y-3">
+              <div
+                v-for="source in userSources"
+                :key="source"
+                class="flex items-center justify-between p-3 border rounded-lg">
+                <span class="text-sm font-mono truncate flex-1 mr-3">{{ source }}</span>
+                <div class="flex items-center gap-2 flex-shrink-0">
+                  <Button size="sm" variant="outline" @click="copyLink(source)">
+                    {{ copiedSource === source ? 'Copied!' : 'Copy Link' }}
+                  </Button>
+                  <a :href="source" target="_blank" rel="noopener">
+                    <Button size="sm" variant="ghost">Open</Button>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </template>
+          <template v-else>
+            <p class="text-sm text-muted-foreground">
+              You haven't added any workshops yet. Add one via the + button on the home page.
+            </p>
+          </template>
+        </CardContent>
+      </Card>
+
+      <!-- Create a Workshop -->
+      <Card>
+        <CardHeader>
+          <CardTitle class="text-xl">Create a Workshop</CardTitle>
+        </CardHeader>
+        <CardContent class="space-y-3">
+          <p class="text-sm text-muted-foreground">
+            Workshops are written in simple YAML — no code needed. You can host them on GitHub Pages, IPFS, or any URL. Learners add them with a single share link.
+          </p>
+          <div class="flex gap-3 flex-wrap">
+            <a href="docs/external-workshop-guide.md" target="_blank" rel="noopener">
+              <Button variant="outline">Read the Guide</Button>
+            </a>
+            <a href="https://github.com/openlearnapp/openlearnapp.github.io" target="_blank" rel="noopener">
+              <Button variant="outline">View on GitHub</Button>
+            </a>
+          </div>
+        </CardContent>
+      </Card>
+
+      <!-- Coach Setup -->
+      <Card>
+        <CardHeader>
+          <CardTitle class="text-xl">Coach Setup</CardTitle>
+        </CardHeader>
+        <CardContent class="space-y-3">
+          <p class="text-sm text-muted-foreground">
+            Add an AI coach to your workshop by configuring a <code class="bg-muted px-1 rounded text-xs">coach.api</code> endpoint in your <code class="bg-muted px-1 rounded text-xs">workshops.yaml</code>. The coach receives learner answers and can provide personalized feedback.
+          </p>
+          <p class="text-sm text-muted-foreground">
+            See the documentation for configuration details and API requirements.
+          </p>
+          <a href="docs/external-workshop-guide.md" target="_blank" rel="noopener">
+            <Button variant="outline">Coach Documentation</Button>
+          </a>
+        </CardContent>
+      </Card>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { useGun } from '../composables/useGun'
+import { useLessons } from '../composables/useLessons'
+import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+
+const router = useRouter()
+const { t } = useI18n()
+const { isLoggedIn } = useGun()
+const { getContentSources } = useLessons()
+
+const copiedSource = ref('')
+const emit = defineEmits(['update-title'])
+
+onMounted(() => {
+  emit('update-title', 'Instructor Dashboard')
+})
+
+const userSources = computed(() => {
+  return getContentSources() || []
+})
+
+async function copyLink(url) {
+  try {
+    await navigator.clipboard.writeText(url)
+    copiedSource.value = url
+    setTimeout(() => { copiedSource.value = '' }, 2000)
+  } catch (e) {
+    console.error('Failed to copy:', e)
+  }
+}
+
+function goToProfile() {
+  router.push({ name: 'profile' })
+}
+</script>

--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -292,6 +292,7 @@ import { useProgress } from '../composables/useProgress'
 import { useAudio } from '../composables/useAudio'
 import { useAssessments } from '../composables/useAssessments'
 import { useFooter } from '../composables/useFooter'
+import { useProfile } from '../composables/useProfile'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { Button } from '@/components/ui/button'
@@ -313,6 +314,7 @@ const { isItemLearned, toggleItemLearned, areAllItemsLearned, progress } = usePr
 const { isLoadingAudio, isPlaying, isPaused, playbackFinished, currentItem, initializeAudio, jumpToExample, cleanup, play, pause } = useAudio()
 const { getAnswer, saveAnswer, validateAnswer } = useAssessments()
 const { setLessonFooter, clearLessonFooter } = useFooter()
+const { trackLastLesson } = useProfile()
 
 const lesson = ref(null)
 const allLessons = ref([])
@@ -690,6 +692,7 @@ onMounted(async () => {
     setLessonFooter(currentLearning, currentWorkshop, nextLessonNumber.value)
 
     await initializeAudio(lesson.value, currentLearning, currentWorkshop, audioSettings.value)
+    trackLastLesson(currentLearning, currentWorkshop, currentLessonNumber)
     restoreDraftsFromSaved()
 
     if (route.query.autoplay) {

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -1,0 +1,241 @@
+<template>
+  <div class="space-y-8">
+    <!-- Not logged in state -->
+    <template v-if="!isLoggedIn">
+      <!-- Sign-in card -->
+      <Card>
+        <CardHeader>
+          <div class="flex flex-col items-center gap-3 py-4">
+            <div class="text-6xl">👤</div>
+            <CardTitle class="text-2xl text-center">{{ $t('profile.notLoggedIn') }}</CardTitle>
+            <p class="text-sm text-muted-foreground text-center">{{ $t('profile.notLoggedInDesc') }}</p>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div class="space-y-3 max-w-sm mx-auto">
+            <div>
+              <Label class="text-sm font-medium mb-1 block">{{ $t('settings.username') }}</Label>
+              <Input v-model="gunUsername" :placeholder="$t('settings.username')" />
+            </div>
+            <div>
+              <Label class="text-sm font-medium mb-1 block">{{ $t('settings.password') }}</Label>
+              <Input v-model="gunPassword" type="password" :placeholder="$t('settings.password')" />
+            </div>
+            <div class="flex gap-3">
+              <Button @click="handleLogin" :disabled="!gunUsername || !gunPassword || isAuthLoading">
+                {{ isAuthLoading ? $t('settings.loggingIn') : $t('settings.login') }}
+              </Button>
+              <Button variant="secondary" @click="handleRegister" :disabled="!gunUsername || !gunPassword || isAuthLoading">
+                {{ isAuthLoading ? $t('settings.registering') : $t('settings.register') }}
+              </Button>
+            </div>
+            <div v-if="authError" class="text-sm text-red-500">{{ authError }}</div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <!-- Local progress (not synced) -->
+      <template v-if="activeWorkshops.length > 0">
+        <div class="text-sm text-muted-foreground text-center">— {{ $t('profile.notLoggedIn') }} —</div>
+        <WorkshopsGrid :workshops="activeWorkshops" :lastVisited="lastVisited" />
+      </template>
+    </template>
+
+    <!-- Logged in state -->
+    <template v-else>
+      <!-- Profile header -->
+      <Card>
+        <CardContent class="pt-6">
+          <div class="flex items-center gap-4">
+            <!-- Avatar circle -->
+            <div
+              class="rounded-full w-16 h-16 text-lg font-bold text-white flex-shrink-0 flex items-center justify-center"
+              :style="{ backgroundColor: getAvatarColor(gunUser) }">
+              {{ getInitials(gunUser) }}
+            </div>
+            <div>
+              <h2 class="text-2xl font-bold">{{ gunUser }}</h2>
+              <p v-if="memberSince" class="text-sm text-muted-foreground">
+                {{ $t('profile.memberSince') }}: {{ memberSince }}
+              </p>
+            </div>
+          </div>
+
+          <!-- Stats row -->
+          <div class="flex gap-6 mt-6 flex-wrap">
+            <div class="text-center">
+              <div class="text-2xl font-bold">{{ userStats.totalLearned }}</div>
+              <div class="text-xs text-muted-foreground">{{ $t('profile.stats.learned') }}</div>
+            </div>
+            <div class="text-center">
+              <div class="text-2xl font-bold">{{ userStats.workshopCount }}</div>
+              <div class="text-xs text-muted-foreground">{{ $t('profile.stats.workshops') }}</div>
+            </div>
+            <div class="text-center">
+              <div class="text-2xl font-bold">{{ userStats.totalAssessments }}</div>
+              <div class="text-xs text-muted-foreground">{{ $t('profile.stats.assessments') }}</div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <!-- Your Workshops -->
+      <div>
+        <h3 class="text-xl font-semibold mb-4">{{ $t('profile.yourWorkshops') }}</h3>
+
+        <template v-if="activeWorkshops.length > 0">
+          <WorkshopsGrid :workshops="activeWorkshops" :lastVisited="lastVisited" />
+        </template>
+
+        <Card v-else>
+          <CardContent class="py-12 text-center text-muted-foreground">
+            {{ $t('profile.noWorkshops') }}
+          </CardContent>
+        </Card>
+      </div>
+
+      <!-- Logout -->
+      <div class="flex justify-center">
+        <Button variant="secondary" @click="handleLogout">{{ $t('profile.logout') }}</Button>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, defineComponent, h } from 'vue'
+import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { useGun } from '../composables/useGun'
+import { useProgress } from '../composables/useProgress'
+import { useAssessments } from '../composables/useAssessments'
+import { useProfile } from '../composables/useProfile'
+import { formatLangName } from '../utils/formatters'
+import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+const router = useRouter()
+const { t } = useI18n()
+const { isLoggedIn, username: gunUser, authError, login, register, logout, loadFromGun } = useGun()
+const { progress, mergeProgress } = useProgress()
+const { assessments, mergeAssessments } = useAssessments()
+const { lastVisited, getAvatarColor, getInitials, getActiveWorkshops, getUserStats, loadLastVisited } = useProfile()
+const gunUsername = ref('')
+const gunPassword = ref('')
+const isAuthLoading = ref(false)
+const memberSince = ref('')
+
+const emit = defineEmits(['update-title'])
+
+onMounted(() => {
+  emit('update-title', t('profile.title'))
+  loadLastVisited()
+
+  // Try to load member since date
+  const stored = localStorage.getItem('memberSince')
+  if (stored) {
+    memberSince.value = new Date(parseInt(stored)).toLocaleDateString()
+  }
+})
+
+const activeWorkshops = computed(() => getActiveWorkshops(progress.value))
+const userStats = computed(() => getUserStats(progress.value, assessments.value))
+
+async function handleLogin() {
+  if (isAuthLoading.value) return
+  isAuthLoading.value = true
+  try {
+    const ok = await login(gunUsername.value, gunPassword.value)
+    if (ok) {
+      gunUsername.value = ''
+      gunPassword.value = ''
+      const remote = await loadFromGun()
+      if (remote) {
+        if (remote.progress) mergeProgress(remote.progress)
+        if (remote.assessments) mergeAssessments(remote.assessments)
+      }
+      // Store member since if not already set
+      if (!localStorage.getItem('memberSince')) {
+        const ts = Date.now()
+        localStorage.setItem('memberSince', ts.toString())
+        memberSince.value = new Date(ts).toLocaleDateString()
+      } else {
+        memberSince.value = new Date(parseInt(localStorage.getItem('memberSince'))).toLocaleDateString()
+      }
+    }
+  } finally {
+    isAuthLoading.value = false
+  }
+}
+
+async function handleRegister() {
+  if (isAuthLoading.value) return
+  isAuthLoading.value = true
+  try {
+    const ok = await register(gunUsername.value, gunPassword.value)
+    if (ok) {
+      gunUsername.value = ''
+      gunPassword.value = ''
+      const ts = Date.now()
+      localStorage.setItem('memberSince', ts.toString())
+      memberSince.value = new Date(ts).toLocaleDateString()
+    }
+  } finally {
+    isAuthLoading.value = false
+  }
+}
+
+function handleLogout() {
+  logout()
+}
+
+// WorkshopsGrid sub-component
+const WorkshopsGrid = defineComponent({
+  name: 'WorkshopsGrid',
+  props: {
+    workshops: Array,
+    lastVisited: Object
+  },
+  setup(props) {
+    return () => h('div', { class: 'grid grid-cols-1 sm:grid-cols-2 gap-4' },
+      props.workshops.map(ws => {
+        const key = `${ws.learning}:${ws.workshop}`
+        const lastLesson = props.lastVisited?.[key] || null
+        const displayName = formatLangName(ws.workshop)
+
+        return h('div', { key, class: 'bg-card border rounded-xl p-4 space-y-3' }, [
+          h('div', { class: 'flex items-start justify-between' }, [
+            h('div', [
+              h('h4', { class: 'font-semibold text-base' }, displayName),
+              h('p', { class: 'text-xs text-muted-foreground' }, ws.learning)
+            ]),
+            h('span', {
+              class: 'text-xs font-medium px-2 py-1 rounded-full bg-primary/10 text-primary'
+            }, `${ws.learnedCount}`)
+          ]),
+          // Progress bar
+          h('div', { class: 'w-full bg-muted rounded-full h-2' }, [
+            h('div', {
+              class: 'bg-primary h-2 rounded-full transition-all',
+              style: { width: `${Math.min(100, (ws.learnedCount / Math.max(ws.learnedCount, 1)) * 100)}%` }
+            })
+          ]),
+          h('p', { class: 'text-xs text-muted-foreground' }, `${ws.learnedCount} items learned`),
+          lastLesson
+            ? h('p', { class: 'text-xs text-muted-foreground' }, `Last: Lesson ${lastLesson.lessonNumber}`)
+            : null,
+          h('a', {
+            href: lastLesson
+              ? `#/${ws.learning}/${ws.workshop}/lesson/${lastLesson.lessonNumber}`
+              : `#/${ws.learning}/${ws.workshop}/lessons`,
+            class: 'inline-flex items-center text-sm font-medium text-primary hover:underline'
+          }, 'Continue →')
+        ])
+      })
+    )
+  }
+})
+</script>


### PR DESCRIPTION
## Summary
- Add user profile page with avatar, display name, and last-visited lesson tracking
- Add instructor dashboard with student overview and progress metrics
- Add avatar/profile navigation in App.vue header
- Add profile and instructor routes
- Track last lesson visited in LessonDetail.vue via `useProfile` composable
- Add i18n keys for profile UI (en, de)

Split from #47 (by @Reza9696).

## Test plan
- [ ] Verify profile page loads and displays user info
- [ ] Verify avatar navigation link appears in header
- [ ] Verify instructor dashboard shows student data
- [ ] Verify last lesson tracking works when visiting a lesson
- [ ] Verify i18n translations render correctly in both EN and DE