### PR TITLE
fix: hide audio button when no files available, scope progress hash per lesson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-03-15
+
+### Fixes
+
+#### Audio button hidden when no audio available (Issue #45)
+- Play button no longer shows for workshops without audio files (Farsi, Arabic)
+- `hasAudio` ref exposed from `useAudio()` — true only when at least one file loaded
+
+#### Progress hash scoped per lesson (Issue #4)
+- Assessment sent-status no longer marks all lessons as "changed" when any item is learned
+- Hash now only includes progress items belonging to that specific lesson
+
 ## 2026-03-10
 
 ### Features

--- a/src/composables/useAudio.js
+++ b/src/composables/useAudio.js
@@ -17,6 +17,7 @@ const readingQueue = ref([])
 const audioElements = ref([]) // Pre-loaded audio elements
 const currentAudio = ref(null) // Currently playing audio element
 const playbackFinished = ref(false)
+const hasAudio = ref(false) // True when at least one audio file loaded successfully
 const lessonTitle = ref('')
 const lessonMetadata = ref({ learning: '', workshop: '', number: '' })
 
@@ -273,6 +274,9 @@ async function initializeAudio(lesson, learning, workshop, settings) {
 
   // Pre-load audio files (filtered by manifest if available)
   audioElements.value = await preloadAudioFiles(readingQueue.value, manifest)
+
+  hasAudio.value = Object.keys(audioElements.value).length > 0
+  console.log(`🔊 Has audio: ${hasAudio.value} (${Object.keys(audioElements.value).length} files loaded)`)
 
   isLoadingAudio.value = false
   currentItemIndex.value = -1
@@ -729,6 +733,7 @@ export function useAudio() {
     isPlaying,
     isPaused,
     playbackFinished,
+    hasAudio,
     currentItem,
     currentItemIndex,
     readingQueue,

--- a/src/views/AssessmentResults.vue
+++ b/src/views/AssessmentResults.vue
@@ -255,9 +255,15 @@ const allEntries = computed(() => {
       }
     })
 
-    // Sent status tracking
+    // Sent status tracking — only include progress items belonging to this lesson
     const workshopProgress = progress.value[`${learning.value}:${workshop.value}`] || {}
-    const currentHash = getLessonHash(lessonKey, workshopProgress)
+    const lessonProgress = {}
+    itemsSeen.forEach(id => {
+      if (workshopProgress[id] !== undefined) {
+        lessonProgress[id] = workshopProgress[id]
+      }
+    })
+    const currentHash = getLessonHash(lessonKey, lessonProgress)
     const lastSent = getLastSent(lessonKey)
     let sentStatus = 'never-sent'
     let sentStatusLabel = t('results.neverSent')

--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -267,9 +267,9 @@
       <div v-if="currentItem" class="truncate">{{ currentItem.text.substring(0, 30) }}...</div>
     </div>
 
-    <!-- Floating play/pause button for mobile -->
+    <!-- Floating play/pause button for mobile — only shown when audio is available -->
     <Button
-      v-if="lesson"
+      v-if="lesson && (isLoadingAudio || hasAudio)"
       size="icon"
       @click="togglePlayPause"
       :disabled="isLoadingAudio"
@@ -310,7 +310,7 @@ const emit = defineEmits(['update-title'])
 const { loadAllLessonsForWorkshop } = useLessons()
 const { settings } = useSettings()
 const { isItemLearned, toggleItemLearned, areAllItemsLearned, progress } = useProgress()
-const { isLoadingAudio, isPlaying, isPaused, playbackFinished, currentItem, initializeAudio, jumpToExample, cleanup, play, pause } = useAudio()
+const { isLoadingAudio, isPlaying, isPaused, playbackFinished, hasAudio, currentItem, initializeAudio, jumpToExample, cleanup, play, pause } = useAudio()
 const { getAnswer, saveAnswer, validateAnswer } = useAssessments()
 const { setLessonFooter, clearLessonFooter } = useFooter()
 


### PR DESCRIPTION
## Summary
- Hide play button for workshops without audio files — Farsi/Arabic no longer show a broken play button (Issue #45)
- Progress sent-status hash scoped per lesson — changing one item no longer marks all lessons as "changed" (Issue #4)

Closes #45
Closes #4

## Test plan
- [ ] Open Farsi or Arabic workshop — play button should not appear
- [ ] Open a workshop with audio — play button appears and works normally
- [ ] Mark a learning item as learned in one lesson — other lessons should NOT change to "changed" status