### PR TITLE
feat: replace screenshot thumbnails with custom SVG artwork

### DIFF
--- a/public/lessons/deutsch/open-learn-feedback/thumbnail.svg
+++ b/public/lessons/deutsch/open-learn-feedback/thumbnail.svg
@@ -1,0 +1,59 @@
+<svg width="1280" height="800" viewBox="0 0 1280 800" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0d4a2a"/>
+      <stop offset="100%" style="stop-color:#1a8a4a"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:rgba(255,255,255,0.15)"/>
+      <stop offset="100%" style="stop-color:rgba(255,255,255,0.04)"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1280" height="800" fill="url(#bg)"/>
+
+  <!-- Subtle dots pattern -->
+  <circle cx="200" cy="150" r="3" fill="rgba(255,255,255,0.06)"/>
+  <circle cx="400" cy="100" r="3" fill="rgba(255,255,255,0.06)"/>
+  <circle cx="900" cy="150" r="3" fill="rgba(255,255,255,0.06)"/>
+  <circle cx="1100" cy="100" r="3" fill="rgba(255,255,255,0.06)"/>
+  <circle cx="150" cy="650" r="3" fill="rgba(255,255,255,0.06)"/>
+  <circle cx="1150" cy="680" r="3" fill="rgba(255,255,255,0.06)"/>
+
+  <!-- Center card -->
+  <rect x="290" y="140" width="700" height="520" rx="28" fill="url(#card)" stroke="rgba(255,255,255,0.18)" stroke-width="1.5"/>
+
+  <!-- Speech bubble icon -->
+  <!-- Main bubble -->
+  <rect x="540" y="200" width="200" height="130" rx="20" fill="rgba(255,255,255,0.92)"/>
+  <!-- Bubble tail -->
+  <path d="M580 330 L560 365 L610 330 Z" fill="rgba(255,255,255,0.92)"/>
+
+  <!-- Lines inside bubble (like text) -->
+  <rect x="562" y="228" width="156" height="12" rx="6" fill="rgba(20,100,55,0.35)"/>
+  <rect x="562" y="252" width="120" height="12" rx="6" fill="rgba(20,100,55,0.25)"/>
+  <rect x="562" y="276" width="140" height="12" rx="6" fill="rgba(20,100,55,0.25)"/>
+
+  <!-- Second smaller bubble (reply) -->
+  <rect x="580" y="375" width="160" height="95" rx="16" fill="rgba(255,255,255,0.55)"/>
+  <path d="M710 375 L730 345 L720 375 Z" fill="rgba(255,255,255,0.55)"/>
+  <!-- Lines inside second bubble -->
+  <rect x="598" y="398" width="124" height="10" rx="5" fill="rgba(20,100,55,0.3)"/>
+  <rect x="598" y="418" width="90" height="10" rx="5" fill="rgba(20,100,55,0.2)"/>
+  <rect x="598" y="438" width="106" height="10" rx="5" fill="rgba(20,100,55,0.2)"/>
+
+  <!-- Stars (rating) -->
+  <text x="555" y="500" font-size="32" fill="rgba(255,220,50,0.9)">★★★★★</text>
+
+  <!-- Main title -->
+  <text x="640" y="570" font-family="Georgia, 'Times New Roman', serif" font-size="72" font-weight="bold"
+        text-anchor="middle" fill="white" letter-spacing="2">Feedback</text>
+
+  <!-- Divider -->
+  <rect x="540" y="592" width="200" height="2" rx="1" fill="rgba(255,255,255,0.35)"/>
+
+  <!-- Label -->
+  <text x="640" y="632" font-family="Arial, Helvetica, sans-serif" font-size="22"
+        text-anchor="middle" fill="rgba(255,255,255,0.55)" letter-spacing="3">OPEN LEARN</text>
+</svg>

--- a/public/lessons/deutsch/open-learn-guide/thumbnail.svg
+++ b/public/lessons/deutsch/open-learn-guide/thumbnail.svg
@@ -1,0 +1,66 @@
+<svg width="1280" height="800" viewBox="0 0 1280 800" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a3a6b"/>
+      <stop offset="100%" style="stop-color:#2563c8"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:rgba(255,255,255,0.15)"/>
+      <stop offset="100%" style="stop-color:rgba(255,255,255,0.04)"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1280" height="800" fill="url(#bg)"/>
+
+  <!-- Subtle grid pattern -->
+  <line x1="0" y1="200" x2="1280" y2="200" stroke="rgba(255,255,255,0.04)" stroke-width="1"/>
+  <line x1="0" y1="400" x2="1280" y2="400" stroke="rgba(255,255,255,0.04)" stroke-width="1"/>
+  <line x1="0" y1="600" x2="1280" y2="600" stroke="rgba(255,255,255,0.04)" stroke-width="1"/>
+  <line x1="320" y1="0" x2="320" y2="800" stroke="rgba(255,255,255,0.04)" stroke-width="1"/>
+  <line x1="640" y1="0" x2="640" y2="800" stroke="rgba(255,255,255,0.04)" stroke-width="1"/>
+  <line x1="960" y1="0" x2="960" y2="800" stroke="rgba(255,255,255,0.04)" stroke-width="1"/>
+
+  <!-- Center card -->
+  <rect x="290" y="140" width="700" height="520" rx="28" fill="url(#card)" stroke="rgba(255,255,255,0.18)" stroke-width="1.5"/>
+
+  <!-- Book icon (open book made from shapes) -->
+  <!-- Left page -->
+  <path d="M570 240 L570 370 Q570 380 580 382 L640 390 L640 260 Q640 248 628 244 Z"
+        fill="rgba(255,255,255,0.9)"/>
+  <!-- Right page -->
+  <path d="M710 240 L710 370 Q710 380 700 382 L640 390 L640 260 Q640 248 652 244 Z"
+        fill="rgba(255,255,255,0.75)"/>
+  <!-- Spine -->
+  <rect x="637" y="248" width="6" height="142" rx="3" fill="rgba(255,255,255,0.5)"/>
+  <!-- Lines on left page -->
+  <line x1="588" y1="285" x2="632" y2="283" stroke="rgba(30,80,180,0.4)" stroke-width="3" stroke-linecap="round"/>
+  <line x1="588" y1="305" x2="632" y2="303" stroke="rgba(30,80,180,0.3)" stroke-width="3" stroke-linecap="round"/>
+  <line x1="588" y1="325" x2="632" y2="323" stroke="rgba(30,80,180,0.3)" stroke-width="3" stroke-linecap="round"/>
+  <line x1="588" y1="345" x2="632" y2="343" stroke="rgba(30,80,180,0.2)" stroke-width="3" stroke-linecap="round"/>
+  <!-- Lines on right page -->
+  <line x1="648" y1="283" x2="692" y2="285" stroke="rgba(30,80,180,0.35)" stroke-width="3" stroke-linecap="round"/>
+  <line x1="648" y1="303" x2="692" y2="305" stroke="rgba(30,80,180,0.25)" stroke-width="3" stroke-linecap="round"/>
+  <line x1="648" y1="323" x2="692" y2="325" stroke="rgba(30,80,180,0.25)" stroke-width="3" stroke-linecap="round"/>
+
+  <!-- Graduation cap above book -->
+  <rect x="608" y="205" width="64" height="8" rx="2" fill="rgba(255,255,255,0.85)"/>
+  <path d="M640 195 L608 213 L640 228 L672 213 Z" fill="rgba(255,255,255,0.9)"/>
+  <line x1="672" y1="213" x2="672" y2="235" stroke="rgba(255,255,255,0.7)" stroke-width="3"/>
+  <circle cx="672" cy="238" r="5" fill="rgba(255,255,255,0.8)"/>
+
+  <!-- Main title -->
+  <text x="640" y="460" font-family="Georgia, 'Times New Roman', serif" font-size="72" font-weight="bold"
+        text-anchor="middle" fill="white" letter-spacing="2">Open Learn</text>
+
+  <!-- Subtitle DE -->
+  <text x="640" y="520" font-family="Arial, Helvetica, sans-serif" font-size="32"
+        text-anchor="middle" fill="rgba(255,255,255,0.8)" letter-spacing="2">Anleitung</text>
+
+  <!-- Divider -->
+  <rect x="540" y="548" width="200" height="2" rx="1" fill="rgba(255,255,255,0.35)"/>
+
+  <!-- Label -->
+  <text x="640" y="588" font-family="Arial, Helvetica, sans-serif" font-size="22"
+        text-anchor="middle" fill="rgba(255,255,255,0.55)" letter-spacing="3">PLATFORM GUIDE</text>
+</svg>

--- a/public/lessons/deutsch/workshops.yaml
+++ b/public/lessons/deutsch/workshops.yaml
@@ -6,13 +6,13 @@ workshops:
     description: "Lerne die Plattform kennen — Videos, Quizze, Labels und mehr. Perfekt für neue Nutzer und Workshop-Ersteller."
     color: "145 45% 92%"
     primaryColor: "220 75% 50%"
-    image: "lessons/deutsch/open-learn-guide/thumbnail.png"
+    image: "lessons/deutsch/open-learn-guide/thumbnail.svg"
   - folder: open-learn-feedback
     code: de-DE
     title: "Open Learn Feedback"
     description: "Teile deine Meinung und hilf mit, die Zukunft von Open Learn zu gestalten."
     color: "145 40% 94%"
     primaryColor: "152 60% 36%"
-    image: "lessons/deutsch/open-learn-feedback/thumbnail.png"
+    image: "lessons/deutsch/open-learn-feedback/thumbnail.svg"
     coach:
       email: "open-learn@felixboehm.it"

--- a/public/lessons/english/open-learn-feedback/thumbnail.svg
+++ b/public/lessons/english/open-learn-feedback/thumbnail.svg
@@ -1,0 +1,42 @@
+<svg width="1280" height="800" viewBox="0 0 1280 800" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0d4a2a"/>
+      <stop offset="100%" style="stop-color:#1a8a4a"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:rgba(255,255,255,0.15)"/>
+      <stop offset="100%" style="stop-color:rgba(255,255,255,0.04)"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1280" height="800" fill="url(#bg)"/>
+  <circle cx="200" cy="150" r="3" fill="rgba(255,255,255,0.06)"/>
+  <circle cx="400" cy="100" r="3" fill="rgba(255,255,255,0.06)"/>
+  <circle cx="900" cy="150" r="3" fill="rgba(255,255,255,0.06)"/>
+  <circle cx="1100" cy="100" r="3" fill="rgba(255,255,255,0.06)"/>
+  <circle cx="150" cy="650" r="3" fill="rgba(255,255,255,0.06)"/>
+  <circle cx="1150" cy="680" r="3" fill="rgba(255,255,255,0.06)"/>
+
+  <rect x="290" y="140" width="700" height="520" rx="28" fill="url(#card)" stroke="rgba(255,255,255,0.18)" stroke-width="1.5"/>
+
+  <rect x="540" y="200" width="200" height="130" rx="20" fill="rgba(255,255,255,0.92)"/>
+  <path d="M580 330 L560 365 L610 330 Z" fill="rgba(255,255,255,0.92)"/>
+  <rect x="562" y="228" width="156" height="12" rx="6" fill="rgba(20,100,55,0.35)"/>
+  <rect x="562" y="252" width="120" height="12" rx="6" fill="rgba(20,100,55,0.25)"/>
+  <rect x="562" y="276" width="140" height="12" rx="6" fill="rgba(20,100,55,0.25)"/>
+
+  <rect x="580" y="375" width="160" height="95" rx="16" fill="rgba(255,255,255,0.55)"/>
+  <path d="M710 375 L730 345 L720 375 Z" fill="rgba(255,255,255,0.55)"/>
+  <rect x="598" y="398" width="124" height="10" rx="5" fill="rgba(20,100,55,0.3)"/>
+  <rect x="598" y="418" width="90" height="10" rx="5" fill="rgba(20,100,55,0.2)"/>
+  <rect x="598" y="438" width="106" height="10" rx="5" fill="rgba(20,100,55,0.2)"/>
+
+  <text x="555" y="500" font-size="32" fill="rgba(255,220,50,0.9)">★★★★★</text>
+
+  <text x="640" y="570" font-family="Georgia, 'Times New Roman', serif" font-size="72" font-weight="bold"
+        text-anchor="middle" fill="white" letter-spacing="2">Feedback</text>
+  <rect x="540" y="592" width="200" height="2" rx="1" fill="rgba(255,255,255,0.35)"/>
+  <text x="640" y="632" font-family="Arial, Helvetica, sans-serif" font-size="22"
+        text-anchor="middle" fill="rgba(255,255,255,0.55)" letter-spacing="3">OPEN LEARN</text>
+</svg>

--- a/public/lessons/english/open-learn-guide/thumbnail.svg
+++ b/public/lessons/english/open-learn-guide/thumbnail.svg
@@ -1,0 +1,46 @@
+<svg width="1280" height="800" viewBox="0 0 1280 800" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a3a6b"/>
+      <stop offset="100%" style="stop-color:#2563c8"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:rgba(255,255,255,0.15)"/>
+      <stop offset="100%" style="stop-color:rgba(255,255,255,0.04)"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1280" height="800" fill="url(#bg)"/>
+  <line x1="0" y1="200" x2="1280" y2="200" stroke="rgba(255,255,255,0.04)" stroke-width="1"/>
+  <line x1="0" y1="400" x2="1280" y2="400" stroke="rgba(255,255,255,0.04)" stroke-width="1"/>
+  <line x1="0" y1="600" x2="1280" y2="600" stroke="rgba(255,255,255,0.04)" stroke-width="1"/>
+  <line x1="320" y1="0" x2="320" y2="800" stroke="rgba(255,255,255,0.04)" stroke-width="1"/>
+  <line x1="640" y1="0" x2="640" y2="800" stroke="rgba(255,255,255,0.04)" stroke-width="1"/>
+  <line x1="960" y1="0" x2="960" y2="800" stroke="rgba(255,255,255,0.04)" stroke-width="1"/>
+
+  <rect x="290" y="140" width="700" height="520" rx="28" fill="url(#card)" stroke="rgba(255,255,255,0.18)" stroke-width="1.5"/>
+
+  <path d="M570 240 L570 370 Q570 380 580 382 L640 390 L640 260 Q640 248 628 244 Z" fill="rgba(255,255,255,0.9)"/>
+  <path d="M710 240 L710 370 Q710 380 700 382 L640 390 L640 260 Q640 248 652 244 Z" fill="rgba(255,255,255,0.75)"/>
+  <rect x="637" y="248" width="6" height="142" rx="3" fill="rgba(255,255,255,0.5)"/>
+  <line x1="588" y1="285" x2="632" y2="283" stroke="rgba(30,80,180,0.4)" stroke-width="3" stroke-linecap="round"/>
+  <line x1="588" y1="305" x2="632" y2="303" stroke="rgba(30,80,180,0.3)" stroke-width="3" stroke-linecap="round"/>
+  <line x1="588" y1="325" x2="632" y2="323" stroke="rgba(30,80,180,0.3)" stroke-width="3" stroke-linecap="round"/>
+  <line x1="588" y1="345" x2="632" y2="343" stroke="rgba(30,80,180,0.2)" stroke-width="3" stroke-linecap="round"/>
+  <line x1="648" y1="283" x2="692" y2="285" stroke="rgba(30,80,180,0.35)" stroke-width="3" stroke-linecap="round"/>
+  <line x1="648" y1="303" x2="692" y2="305" stroke="rgba(30,80,180,0.25)" stroke-width="3" stroke-linecap="round"/>
+  <line x1="648" y1="323" x2="692" y2="325" stroke="rgba(30,80,180,0.25)" stroke-width="3" stroke-linecap="round"/>
+
+  <rect x="608" y="205" width="64" height="8" rx="2" fill="rgba(255,255,255,0.85)"/>
+  <path d="M640 195 L608 213 L640 228 L672 213 Z" fill="rgba(255,255,255,0.9)"/>
+  <line x1="672" y1="213" x2="672" y2="235" stroke="rgba(255,255,255,0.7)" stroke-width="3"/>
+  <circle cx="672" cy="238" r="5" fill="rgba(255,255,255,0.8)"/>
+
+  <text x="640" y="460" font-family="Georgia, 'Times New Roman', serif" font-size="72" font-weight="bold"
+        text-anchor="middle" fill="white" letter-spacing="2">Open Learn</text>
+  <text x="640" y="520" font-family="Arial, Helvetica, sans-serif" font-size="32"
+        text-anchor="middle" fill="rgba(255,255,255,0.8)" letter-spacing="2">Guide</text>
+  <rect x="540" y="548" width="200" height="2" rx="1" fill="rgba(255,255,255,0.35)"/>
+  <text x="640" y="588" font-family="Arial, Helvetica, sans-serif" font-size="22"
+        text-anchor="middle" fill="rgba(255,255,255,0.55)" letter-spacing="3">PLATFORM GUIDE</text>
+</svg>

--- a/public/lessons/english/workshops.yaml
+++ b/public/lessons/english/workshops.yaml
@@ -6,13 +6,13 @@ workshops:
     description: "Learn how the platform works — videos, quizzes, labels, and more. Perfect for new users and workshop creators."
     color: "145 45% 92%"
     primaryColor: "220 75% 50%"
-    image: "lessons/english/open-learn-guide/thumbnail.png"
+    image: "lessons/english/open-learn-guide/thumbnail.svg"
   - folder: open-learn-feedback
     code: en-US
     title: "Open Learn Feedback"
     description: "Share your thoughts and help shape the future of Open Learn."
     color: "145 40% 94%"
     primaryColor: "152 60% 36%"
-    image: "lessons/english/open-learn-feedback/thumbnail.png"
+    image: "lessons/english/open-learn-feedback/thumbnail.svg"
     coach:
       email: "open-learn@felixboehm.it"


### PR DESCRIPTION
## Summary
- Replace existing screenshot-based thumbnails with clean, purpose-built SVG artwork
- **Open Learn Guide**: blue gradient background, open book + graduation cap icon
- **Open Learn Feedback**: green gradient background, speech bubbles + star rating icon
- All artwork is 100% original SVG — no external sources, no copyright concerns
- Updated `workshops.yaml` for both `deutsch` and `english` to reference `.svg` files

## Test plan
- [ ] German interface: Guide and Feedback cards show new thumbnails
- [ ] English interface: Guide and Feedback cards show new thumbnails
- [ ] Thumbnails look clean — no desktop screenshots visible
- [ ] Dark mode: thumbnails still look good