### PR TITLE
feat: user profile page with avatar, workshops, and continue button (Issue #48 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-03-16
+
+### Features
+
+#### User Profile — Phase 1 (PR #58, Issue #48)
+- Add `/profile` route with a dedicated login/register page and profile view
+- Profile shows identicon avatar (generated from username), display name, join date, and total items learned
+- Active workshops listed with progress bars and "Continue" button that resumes the last visited lesson
+- Track last visited lesson per workshop in localStorage via `useProgress`
+- Avatar button appears in the navigation bar when logged in — taps to open the profile
+- Moved login/register from Settings to the new Profile page; Settings now shows a link to the Profile page
+
 ## 2026-03-10
 
 ### Features

--- a/src/App.vue
+++ b/src/App.vue
@@ -123,6 +123,20 @@
             <span v-else>📚</span>
           </Button>
 
+          <!-- Profile avatar (visible when logged in, hidden on profile page) -->
+          <button
+            v-if="!isHomePage && isGunLoggedIn && route.name !== 'profile'"
+            @click="goToProfile"
+            class="flex-shrink-0 w-10 h-10 rounded-full overflow-hidden border-2 border-white/60 hover:border-white transition"
+            :title="$t('nav.profile')"
+            :aria-label="$t('nav.profile')">
+            <svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+              <rect width="40" height="40" :fill="`hsl(${avatarHue}, 30%, 85%)`" />
+              <text x="20" y="27" text-anchor="middle" font-size="18" font-weight="bold"
+                :fill="`hsl(${avatarHue}, 65%, 35%)`" font-family="Arial, sans-serif">{{ avatarInitial }}</text>
+            </svg>
+          </button>
+
           <!-- Settings button (hidden on home and settings pages) -->
           <Button
             v-if="!isHomePage && route.name !== 'settings'"
@@ -204,6 +218,7 @@ import { useSettings } from './composables/useSettings'
 import { useLessons } from './composables/useLessons'
 import { useLanguage } from './composables/useLanguage'
 import { useFooter } from './composables/useFooter'
+import { useGun } from './composables/useGun'
 import { isRtlLocale } from './i18n'
 import { formatLangName } from './utils/formatters'
 import { Button } from '@/components/ui/button'
@@ -220,8 +235,18 @@ const { settings } = useSettings()
 const { availableContent, getWorkshopMeta, workshopMeta, loadAvailableContent, loadWorkshopsForLanguage } = useLessons()
 const { selectedLanguage, getFlag, setLanguage } = useLanguage()
 const { nextLessonNumber: footerNextLesson, lessonLearning, lessonWorkshop } = useFooter()
+const { isLoggedIn: isGunLoggedIn, username: gunUsername } = useGun()
 
 const isRtl = computed(() => isRtlLocale(locale.value))
+
+// Avatar for logged-in user (initial letter)
+const avatarInitial = computed(() => (gunUsername.value ? gunUsername.value[0].toUpperCase() : ''))
+function simpleHash(str) {
+  let h = 5381
+  for (let i = 0; i < str.length; i++) { h = ((h << 5) + h) + str.charCodeAt(i); h = h & 0xffffffff }
+  return Math.abs(h)
+}
+const avatarHue = computed(() => simpleHash(gunUsername.value || '') % 360)
 
 // Deduplicated list of available languages
 const learningLanguages = computed(() => {
@@ -408,6 +433,12 @@ function goBack() {
 function goToSettings() {
   if (route.name !== 'settings') {
     router.push({ name: 'settings' })
+  }
+}
+
+function goToProfile() {
+  if (route.name !== 'profile') {
+    router.push({ name: 'profile' })
   }
 }
 

--- a/src/composables/useProgress.js
+++ b/src/composables/useProgress.js
@@ -5,6 +5,9 @@ import { useGun } from './useGun'
 // Structure: { "learning:workshop": { "itemId": true, ... } }
 const progress = ref({})
 
+// Last visited lesson per workshop: { "learning:workshop": "lesson-number" }
+const lastVisited = ref({})
+
 let isInitialized = false
 
 // Get the storage key for a specific workshop
@@ -32,6 +35,25 @@ function loadProgress() {
       progress.value = {}
     }
   }
+  const savedVisited = localStorage.getItem('lastVisited')
+  if (savedVisited) {
+    try {
+      lastVisited.value = JSON.parse(savedVisited)
+    } catch {
+      lastVisited.value = {}
+    }
+  }
+}
+
+// Track the last visited lesson for a workshop
+function setLastVisited(learning, workshop, number) {
+  const key = getWorkshopKey(learning, workshop)
+  lastVisited.value[key] = String(number)
+  localStorage.setItem('lastVisited', JSON.stringify(lastVisited.value))
+}
+
+function getLastVisited(learning, workshop) {
+  return lastVisited.value[getWorkshopKey(learning, workshop)] || null
 }
 
 // Check if an item is learned
@@ -110,11 +132,14 @@ export function useProgress() {
 
   return {
     progress,
+    lastVisited,
     loadProgress,
     isItemLearned,
     toggleItemLearned,
     areAllItemsLearned,
     getProgress,
-    mergeProgress
+    mergeProgress,
+    setLastVisited,
+    getLastVisited
   }
 }

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -12,7 +12,19 @@
     "coach": "Coach",
     "learningItems": "Lernelemente",
     "settings": "Einstellungen",
-    "done": "Fertig"
+    "done": "Fertig",
+    "profile": "Profil",
+    "loading": "Lädt..."
+  },
+  "profile": {
+    "title": "Mein Profil",
+    "signIn": "Anmelden",
+    "signInDesc": "Melde dich an, um deinen Fortschritt geräteübergreifend zu synchronisieren.",
+    "memberSince": "Mitglied seit",
+    "itemsLearned": "Elemente gelernt",
+    "activeWorkshops": "Aktive Workshops",
+    "continue": "Lektion fortsetzen",
+    "noWorkshopsYet": "Starte einen Workshop, um deinen Fortschritt hier zu sehen."
   },
   "home": {
     "title": "Lerne alles. Kostenlos. In deinem Tempo.",
@@ -154,7 +166,9 @@
     "importSuccess": "Daten erfolgreich importiert.",
     "readError": "Datei konnte nicht gelesen werden.",
     "loginSuccess": "Angemeldet und synchronisiert.",
-    "registerSuccess": "Registriert und synchronisiert."
+    "registerSuccess": "Registriert und synchronisiert.",
+    "manageAccount": "Anmelden / Registrieren",
+    "viewProfile": "Profil anzeigen"
   },
   "lesson": {
     "typeAnswer": "Deine Antwort eingeben...",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -12,7 +12,19 @@
     "coach": "Coach",
     "learningItems": "Learning items",
     "settings": "Settings",
-    "done": "Done"
+    "done": "Done",
+    "profile": "Profile",
+    "loading": "Loading..."
+  },
+  "profile": {
+    "title": "My Profile",
+    "signIn": "Sign In",
+    "signInDesc": "Sign in to sync your progress across devices and access your profile.",
+    "memberSince": "Member since",
+    "itemsLearned": "items learned",
+    "activeWorkshops": "Active Workshops",
+    "continue": "Continue lesson",
+    "noWorkshopsYet": "Start a workshop to track your progress here."
   },
   "home": {
     "title": "Learn anything. For free. On your terms.",
@@ -154,7 +166,9 @@
     "importSuccess": "Data imported successfully.",
     "readError": "Could not read file.",
     "loginSuccess": "Logged in and synced.",
-    "registerSuccess": "Registered and synced."
+    "registerSuccess": "Registered and synced.",
+    "manageAccount": "Sign in / Register",
+    "viewProfile": "View Profile"
   },
   "lesson": {
     "typeAnswer": "Type your answer...",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,6 +9,7 @@ import Coach from '../views/Coach.vue'
 import Settings from '../views/Settings.vue'
 import AddSource from '../views/AddSource.vue'
 import Creators from '../views/Creators.vue'
+import Profile from '../views/Profile.vue'
 
 const routes = [
   {
@@ -73,6 +74,12 @@ const routes = [
     path: '/creators',
     name: 'creators',
     component: Creators,
+    meta: { title: null }
+  },
+  {
+    path: '/profile',
+    name: 'profile',
+    component: Profile,
     meta: { title: null }
   }
 ]

--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -309,7 +309,7 @@ const emit = defineEmits(['update-title'])
 
 const { loadAllLessonsForWorkshop } = useLessons()
 const { settings } = useSettings()
-const { isItemLearned, toggleItemLearned, areAllItemsLearned, progress } = useProgress()
+const { isItemLearned, toggleItemLearned, areAllItemsLearned, progress, setLastVisited } = useProgress()
 const { isLoadingAudio, isPlaying, isPaused, playbackFinished, currentItem, initializeAudio, jumpToExample, cleanup, play, pause } = useAudio()
 const { getAnswer, saveAnswer, validateAnswer } = useAssessments()
 const { setLessonFooter, clearLessonFooter } = useFooter()
@@ -685,6 +685,9 @@ onMounted(async () => {
 
   if (lesson.value) {
     emit('update-title', `${t('results.lessonLabel')} ${lesson.value.number}`)
+
+    // Track last visited lesson for profile "continue" feature
+    setLastVisited(currentLearning, currentWorkshop, lesson.value.number)
 
     // Set footer navigation data
     setLessonFooter(currentLearning, currentWorkshop, nextLessonNumber.value)

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -1,0 +1,300 @@
+<template>
+  <div class="space-y-8">
+
+    <!-- Not logged in: show login/register form -->
+    <template v-if="!isLoggedIn">
+      <Card>
+        <CardHeader>
+          <CardTitle class="text-2xl">{{ $t('profile.signIn') }}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p class="text-sm text-muted-foreground mb-4">
+            {{ $t('profile.signInDesc') }}
+          </p>
+          <div class="space-y-3">
+            <div>
+              <Label class="text-sm font-medium mb-1 block">{{ $t('settings.username') }}</Label>
+              <Input v-model="gunUsername" :placeholder="$t('settings.username')" @keyup.enter="handleLogin" />
+            </div>
+            <div>
+              <Label class="text-sm font-medium mb-1 block">{{ $t('settings.password') }}</Label>
+              <Input v-model="gunPassword" type="password" :placeholder="$t('settings.password')" @keyup.enter="handleLogin" />
+            </div>
+            <div class="flex gap-3">
+              <Button @click="handleLogin" :disabled="!gunUsername || !gunPassword || isAuthLoading">
+                {{ isAuthLoading ? $t('settings.loggingIn') : $t('settings.login') }}
+              </Button>
+              <Button variant="secondary" @click="handleRegister" :disabled="!gunUsername || !gunPassword || isAuthLoading">
+                {{ isAuthLoading ? $t('settings.registering') : $t('settings.register') }}
+              </Button>
+            </div>
+          </div>
+          <div v-if="authError" class="mt-3 text-sm text-red-500">{{ authError }}</div>
+          <div v-if="authMessage" class="mt-3 text-sm text-green-600 dark:text-green-400">{{ authMessage }}</div>
+        </CardContent>
+      </Card>
+    </template>
+
+    <!-- Logged in: show profile -->
+    <template v-else>
+      <!-- Avatar + name card -->
+      <Card>
+        <CardContent class="pt-6">
+          <div class="flex items-center gap-6">
+            <!-- SVG identicon avatar -->
+            <div class="flex-shrink-0 rounded-full overflow-hidden w-20 h-20 border-2 border-primary/30">
+              <svg width="80" height="80" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
+                <rect width="80" height="80" :fill="avatarBg" />
+                <g v-for="(cell, i) in avatarCells" :key="i">
+                  <rect
+                    v-if="cell.filled"
+                    :x="cell.x"
+                    :y="cell.y"
+                    width="16"
+                    height="16"
+                    :fill="avatarColor"
+                  />
+                </g>
+              </svg>
+            </div>
+            <div class="flex-1 min-w-0">
+              <h2 class="text-2xl font-bold truncate">{{ username }}</h2>
+              <p class="text-sm text-muted-foreground mt-1">
+                {{ $t('profile.memberSince') }} {{ joinDate }}
+              </p>
+              <p class="text-sm text-muted-foreground">
+                {{ totalLearned }} {{ $t('profile.itemsLearned') }}
+              </p>
+            </div>
+            <Button variant="secondary" size="sm" @click="handleLogout" class="flex-shrink-0">
+              {{ $t('settings.logout') }}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <!-- Active workshops -->
+      <Card v-if="activeWorkshops.length > 0">
+        <CardHeader>
+          <CardTitle class="text-xl">{{ $t('profile.activeWorkshops') }}</CardTitle>
+        </CardHeader>
+        <CardContent class="space-y-4">
+          <div
+            v-for="ws in activeWorkshops"
+            :key="ws.key"
+            class="border rounded-lg p-4 space-y-2">
+            <div class="flex items-center justify-between gap-4">
+              <div class="min-w-0">
+                <p class="font-semibold truncate">{{ ws.displayName }}</p>
+                <p class="text-sm text-muted-foreground">
+                  {{ ws.learnedCount }} {{ $t('profile.itemsLearned') }}
+                </p>
+              </div>
+              <Button
+                v-if="ws.lastLesson"
+                size="sm"
+                @click="continueWorkshop(ws)">
+                {{ $t('profile.continue') }} {{ ws.lastLesson }}
+              </Button>
+            </div>
+            <!-- Progress bar -->
+            <div class="w-full bg-muted rounded-full h-2">
+              <div
+                class="bg-primary rounded-full h-2 transition-all"
+                :style="{ width: ws.progressPercent + '%' }">
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <!-- No workshops yet -->
+      <Card v-else>
+        <CardContent class="pt-6 text-center text-muted-foreground">
+          <p>{{ $t('profile.noWorkshopsYet') }}</p>
+        </CardContent>
+      </Card>
+    </template>
+
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { useGun } from '../composables/useGun'
+import { useProgress } from '../composables/useProgress'
+import { useAssessments } from '../composables/useAssessments'
+import { formatLangName } from '../utils/formatters'
+import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import { Input } from '@/components/ui/input'
+
+const emit = defineEmits(['update-title'])
+const { t } = useI18n()
+const router = useRouter()
+
+const { isLoggedIn, username, authError, isSyncing, login, register, logout, loadFromGun } = useGun()
+const { progress, lastVisited, mergeProgress } = useProgress()
+const { assessments, mergeAssessments } = useAssessments()
+
+emit('update-title', t('profile.title'))
+
+const gunUsername = ref('')
+const gunPassword = ref('')
+const authMessage = ref('')
+const isAuthLoading = ref(false)
+
+// --- Avatar generation ---
+// Deterministic identicon: 5×5 symmetric grid based on username hash
+
+function simpleHash(str) {
+  let h = 5381
+  for (let i = 0; i < str.length; i++) {
+    h = ((h << 5) + h) + str.charCodeAt(i)
+    h = h & 0xffffffff
+  }
+  return Math.abs(h)
+}
+
+const avatarColor = computed(() => {
+  if (!username.value) return '#6366f1'
+  const h = simpleHash(username.value)
+  const hue = h % 360
+  return `hsl(${hue}, 65%, 50%)`
+})
+
+const avatarBg = computed(() => {
+  if (!username.value) return '#e0e7ff'
+  const h = simpleHash(username.value)
+  const hue = h % 360
+  return `hsl(${hue}, 30%, 92%)`
+})
+
+// 5×5 grid, mirrored left-right for symmetry. 80px / 5 = 16px per cell.
+const avatarCells = computed(() => {
+  const name = username.value || ''
+  const hash = simpleHash(name)
+  const cells = []
+  // 5 rows × 3 unique columns (mirrored to 5)
+  for (let row = 0; row < 5; row++) {
+    for (let col = 0; col < 5; col++) {
+      const mirrorCol = col < 3 ? col : 4 - col
+      const bitIndex = row * 3 + mirrorCol
+      const filled = (hash >> bitIndex) & 1
+      cells.push({ x: col * 16, y: row * 16, filled: !!filled })
+    }
+  }
+  return cells
+})
+
+// --- Join date ---
+const JOIN_DATE_KEY = 'profileJoinDate'
+
+const joinDate = computed(() => {
+  if (!isLoggedIn.value) return ''
+  let stored = localStorage.getItem(JOIN_DATE_KEY)
+  if (!stored) {
+    stored = new Date().toISOString().slice(0, 10)
+    localStorage.setItem(JOIN_DATE_KEY, stored)
+  }
+  return stored
+})
+
+// --- Stats ---
+const totalLearned = computed(() => {
+  let count = 0
+  for (const items of Object.values(progress.value)) {
+    count += Object.values(items).filter(v => v === true).length
+  }
+  return count
+})
+
+// --- Active workshops ---
+const activeWorkshops = computed(() => {
+  const seen = new Set()
+  const result = []
+
+  for (const key of Object.keys(progress.value)) {
+    const items = progress.value[key]
+    if (Object.keys(items).length === 0) continue
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    const [learning, workshop] = key.split(':')
+    const learnedCount = Object.values(items).filter(v => v === true).length
+    const lastLesson = lastVisited.value[key] || null
+
+    result.push({
+      key,
+      learning,
+      workshop,
+      displayName: formatLangName(workshop),
+      learnedCount,
+      lastLesson,
+      progressPercent: Math.min(100, learnedCount * 2) // rough bar fill
+    })
+  }
+
+  return result.sort((a, b) => b.learnedCount - a.learnedCount)
+})
+
+function continueWorkshop(ws) {
+  if (ws.lastLesson) {
+    router.push({
+      name: 'lesson-detail',
+      params: { learning: ws.learning, workshop: ws.workshop, number: ws.lastLesson }
+    })
+  } else {
+    router.push({
+      name: 'lessons-overview',
+      params: { learning: ws.learning, workshop: ws.workshop }
+    })
+  }
+}
+
+// --- Auth ---
+async function handleLogin() {
+  if (isAuthLoading.value) return
+  isAuthLoading.value = true
+  authMessage.value = ''
+  try {
+    const ok = await login(gunUsername.value, gunPassword.value)
+    if (ok) {
+      gunUsername.value = ''
+      gunPassword.value = ''
+      const remote = await loadFromGun()
+      if (remote) {
+        if (remote.progress) mergeProgress(remote.progress)
+        if (remote.assessments) mergeAssessments(remote.assessments)
+      }
+      authMessage.value = t('settings.loginSuccess')
+    }
+  } finally {
+    isAuthLoading.value = false
+  }
+}
+
+async function handleRegister() {
+  if (isAuthLoading.value) return
+  isAuthLoading.value = true
+  authMessage.value = ''
+  try {
+    const ok = await register(gunUsername.value, gunPassword.value)
+    if (ok) {
+      gunUsername.value = ''
+      gunPassword.value = ''
+      authMessage.value = t('settings.registerSuccess')
+    }
+  } finally {
+    isAuthLoading.value = false
+  }
+}
+
+function handleLogout() {
+  logout()
+  authMessage.value = ''
+}
+</script>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="space-y-8">
-    <!-- Gun Account Section -->
+    <!-- Account Section -->
     <Card>
       <CardHeader>
         <CardTitle class="text-2xl">{{ $t('settings.accountSync') }}</CardTitle>
@@ -10,42 +10,17 @@
           <p class="text-sm text-muted-foreground mb-4">
             {{ $t('settings.accountSyncDesc') }}
           </p>
-          <div class="space-y-3">
-            <div>
-              <Label class="text-sm font-medium mb-1 block">{{ $t('settings.username') }}</Label>
-              <Input v-model="gunUsername" :placeholder="$t('settings.username')" />
-            </div>
-            <div>
-              <Label class="text-sm font-medium mb-1 block">{{ $t('settings.password') }}</Label>
-              <Input v-model="gunPassword" type="password" :placeholder="$t('settings.password')" />
-            </div>
-            <div class="flex gap-3">
-              <Button @click="handleLogin" :disabled="!gunUsername || !gunPassword || isAuthLoading">
-                {{ isAuthLoading ? $t('settings.loggingIn') : $t('settings.login') }}
-              </Button>
-              <Button variant="secondary" @click="handleRegister" :disabled="!gunUsername || !gunPassword || isAuthLoading">
-                {{ isAuthLoading ? $t('settings.registering') : $t('settings.register') }}
-              </Button>
-            </div>
-          </div>
+          <Button @click="goToProfile">{{ $t('settings.manageAccount') }}</Button>
         </template>
-
         <template v-else>
           <p class="text-sm text-muted-foreground mb-4">
             {{ $t('settings.signedInAs') }} <span class="font-semibold text-foreground">{{ gunUser }}</span>
             <span v-if="isSyncing" class="ml-2 text-xs text-muted-foreground">({{ $t('settings.syncing') }})</span>
           </p>
           <div class="flex gap-3">
-            <Button variant="secondary" @click="handleLogout">{{ $t('settings.logout') }}</Button>
+            <Button variant="secondary" @click="goToProfile">{{ $t('settings.viewProfile') }}</Button>
           </div>
         </template>
-
-        <div v-if="authError" class="mt-3 text-sm text-red-500">
-          {{ authError }}
-        </div>
-        <div v-if="syncMessage" class="mt-3 text-sm text-green-600 dark:text-green-400">
-          {{ syncMessage }}
-        </div>
       </CardContent>
     </Card>
 
@@ -200,6 +175,7 @@
 <script setup>
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 import { useSettings } from '../composables/useSettings'
 import { useProgress } from '../composables/useProgress'
 import { useAssessments } from '../composables/useAssessments'
@@ -212,63 +188,18 @@ import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
 
 const { t } = useI18n()
+const router = useRouter()
 const { settings } = useSettings()
 const { progress, getProgress, mergeProgress } = useProgress()
 const { assessments, getAssessments, mergeAssessments } = useAssessments()
-const { isLoggedIn, username: gunUser, authError, isSyncing, login, register, logout, loadFromGun } = useGun()
+const { isLoggedIn, username: gunUser, isSyncing } = useGun()
 
 const importMessage = ref('')
 const importMessageError = ref(false)
 const selectedWorkshop = ref('')
 
-const gunUsername = ref('')
-const gunPassword = ref('')
-const syncMessage = ref('')
-const isAuthLoading = ref(false)
-
-async function handleLogin() {
-  if (isAuthLoading.value) return
-  isAuthLoading.value = true
-  syncMessage.value = ''
-  try {
-    const ok = await login(gunUsername.value, gunPassword.value)
-    if (ok) {
-      gunUsername.value = ''
-      gunPassword.value = ''
-      const remote = await loadFromGun()
-      if (remote) {
-        if (remote.progress) mergeProgress(remote.progress)
-        if (remote.assessments) mergeAssessments(remote.assessments)
-        if (remote.settings) {
-          Object.assign(settings, remote.settings)
-        }
-      }
-      syncMessage.value = t('settings.loginSuccess')
-    }
-  } finally {
-    isAuthLoading.value = false
-  }
-}
-
-async function handleRegister() {
-  if (isAuthLoading.value) return
-  isAuthLoading.value = true
-  syncMessage.value = ''
-  try {
-    const ok = await register(gunUsername.value, gunPassword.value)
-    if (ok) {
-      gunUsername.value = ''
-      gunPassword.value = ''
-      syncMessage.value = t('settings.registerSuccess')
-    }
-  } finally {
-    isAuthLoading.value = false
-  }
-}
-
-function handleLogout() {
-  logout()
-  syncMessage.value = ''
+function goToProfile() {
+  router.push({ name: 'profile' })
 }
 
 const availableWorkshops = computed(() => {


### PR DESCRIPTION
## Summary

Phase 1 of Issue #48 — User Profile & Instructor Dashboard.

- New `/profile` route: dedicated login/register form (when logged out) + full profile page (when logged in)
- Profile shows a deterministic SVG identicon avatar, username, join date, and total items learned
- Active workshops listed with progress bars and a **Continue** button that jumps to the last visited lesson
- Last visited lesson tracked per workshop in `localStorage` via new `setLastVisited` / `getLastVisited` in `useProgress`
- When logged in, an avatar button appears in the navigation bar on every page — taps to open the profile
- Login/register moved from Settings to the Profile page; Settings now shows a "Sign in / Register" or "View Profile" link

## Related Issues

Part of #48 (Phase 1)

## Changes

- `src/views/Profile.vue` — new view (login form + profile display)
- `src/composables/useProgress.js` — added `lastVisited` state, `setLastVisited()`, `getLastVisited()`
- `src/views/LessonDetail.vue` — calls `setLastVisited` on lesson load
- `src/router/index.js` — added `/profile` route
- `src/App.vue` — avatar button in nav when logged in; `useGun` integration; `goToProfile()`
- `src/views/Settings.vue` — replaced auth form with link to Profile page
- `src/i18n/en.json` + `de.json` — added `nav.profile`, `profile.*`, `settings.manageAccount`, `settings.viewProfile`
- `CHANGELOG.md` — 2026-03-16 entry

## Test plan

- [ ] Go to `#/profile` when logged out → login/register form appears
- [ ] Register a new user → redirected to profile view, avatar shown
- [ ] Login with existing user → profile view with workshops shown
- [ ] Open any lesson → navigate to profile → workshop listed with Continue button
- [ ] Click Continue → lands on the correct lesson
- [ ] When logged in, avatar appears in the nav bar on every page
- [ ] Settings page → shows "Sign in / Register" link (when logged out) or "View Profile" (when logged in)