### PR TITLE
fix: spacebar pause/resume in story mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -399,10 +399,10 @@ function handleClickOutside(e) {
   }
 }
 
-// Spacebar to pause/resume audio (global — works in normal and story mode)
+// Spacebar to pause/resume audio (normal mode only — story mode handles its own)
 function handleKeydown(e) {
   if (e.code !== 'Space') return
-  // Don't intercept if user is typing in an input/textarea
+  if (isStoryMode.value) return
   const tag = e.target.tagName
   if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return
 

--- a/src/views/StoryView.vue
+++ b/src/views/StoryView.vue
@@ -106,7 +106,7 @@ const route = useRoute()
 const emit = defineEmits(['update-title'])
 
 const { loadAllLessonsForWorkshop, resolveWorkshopKey } = useLessons()
-const { initializeAudio, cleanup, hasAudio, playSingleItem, readingQueue, pause: audioPause, isPlaying, currentAudio } = useAudio()
+const { initializeAudio, cleanup, hasAudio, playSingleItem, readingQueue, currentAudio } = useAudio()
 const { settings } = useSettings()
 
 // State machine
@@ -313,14 +313,16 @@ function togglePause() {
   }
 }
 
-// Listen for spacebar pause from App.vue — sync our paused state
-watch(isPlaying, (playing) => {
-  // If App.vue paused via spacebar while we were playing, sync
-  if (!playing && !paused.value && state.value === 'narrating') {
-    paused.value = true
-    clearAutoAdvance()
+// Spacebar to toggle pause in story mode
+function handleKeydown(e) {
+  if (e.code !== 'Space') return
+  const tag = e.target.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return
+  e.preventDefault()
+  if (state.value === 'narrating') {
+    togglePause()
   }
-})
+}
 
 function advanceSection() {
   if (!currentLesson.value?.sections) return
@@ -427,10 +429,12 @@ function goToOverview() {
 }
 
 onMounted(() => {
+  document.addEventListener('keydown', handleKeydown)
   loadAndStart()
 })
 
 onUnmounted(() => {
+  document.removeEventListener('keydown', handleKeydown)
   clearAutoAdvance()
   cancelExit()
   cleanup()


### PR DESCRIPTION
## Summary

- Story mode now handles spacebar via its own keydown listener with proper togglePause()
- App.vue skips spacebar when in story mode to avoid conflicting with full queue playback
- Play/pause button toggles correctly in both directions

## Test plan

- [ ] Story mode: space pauses — shows "Paused" + play icon
- [ ] Space again — resumes audio + auto-advance, shows pause icon
- [ ] Normal mode: spacebar pause/resume still works unchanged
- [ ] `pnpm test` / `pnpm build` pass