### PR TITLE
fix: cleaner story UI with left/right navigation

### DIFF
--- a/src/views/StoryView.vue
+++ b/src/views/StoryView.vue
@@ -111,9 +111,13 @@
           </div>
         </div>
 
-        <!-- Narration text overlay (bottom) -->
-        <div v-if="state === 'narrating'" class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 via-black/50 to-transparent p-6 pb-10 pt-16">
-          <p class="text-white text-xl md:text-2xl leading-relaxed">{{ currentNarrationText }}</p>
+        <!-- Narration text overlay -->
+        <div v-if="state === 'narrating'"
+          class="absolute left-0 right-0 p-6"
+          :class="currentSectionImage
+            ? 'bottom-0 bg-gradient-to-t from-black/80 via-black/50 to-transparent pb-10 pt-16'
+            : 'inset-0 flex items-center justify-center'">
+          <p class="text-white text-xl md:text-2xl leading-relaxed" :class="!currentSectionImage && 'text-center'">{{ currentNarrationText }}</p>
         </div>
       </div>
     </template>


### PR DESCRIPTION
## Summary

- Remove "Tap to skip", "Narrator" label, and "Paused" overlay text
- More bottom padding on narration text and image for better spacing
- Click left half to go back, right half to advance (Instagram stories style)
- Navigation works while paused — moves text without restarting audio

## Test plan

- [ ] Click right side — advances narration
- [ ] Click left side — goes back to previous narration
- [ ] While paused: left/right still works, no audio restart
- [ ] No "Tap to skip", "Narrator", or "Paused" text visible
- [ ] Narration text has comfortable bottom spacing