### PR TITLE
fix: show correct play/pause state when autoplay is blocked

### DIFF
--- a/src/composables/useAudio.js
+++ b/src/composables/useAudio.js
@@ -668,6 +668,7 @@ async function playSingleItem(index, settings, onEnded) {
 
   } catch (error) {
     console.error('❌ Error playing single item:', error)
+    throw error
   }
 }
 

--- a/src/views/StoryView.vue
+++ b/src/views/StoryView.vue
@@ -271,7 +271,7 @@ function navigateGoto(goto) {
 }
 
 // Play audio for current example, auto-advance when done
-function playCurrentAudio() {
+async function playCurrentAudio() {
   if (!audioReady.value) {
     scheduleAutoAdvance(2000)
     return
@@ -283,11 +283,16 @@ function playCurrentAudio() {
             item.type === 'question'
   )
   if (idx !== -1) {
-    playSingleItem(idx, audioSettings.value, () => {
-      if (!paused.value) {
-        scheduleAutoAdvance(800)
-      }
-    })
+    try {
+      await playSingleItem(idx, audioSettings.value, () => {
+        if (!paused.value) {
+          scheduleAutoAdvance(800)
+        }
+      })
+    } catch {
+      // Browser blocked autoplay (e.g. after reload) — show play button
+      paused.value = true
+    }
   } else {
     scheduleAutoAdvance(2000)
   }


### PR DESCRIPTION
## Summary

- Re-throw audio play errors from `playSingleItem` so callers can handle them
- In `StoryView`, catch autoplay failures and set `paused = true` so the button correctly shows "play" instead of "pause"
- User taps play (user gesture), audio works from there

## Test plan

- [ ] Reload page while in story mode — play button shows ▶ (not ⏸)
- [ ] Tap play — audio starts and button switches to ⏸
- [ ] Normal navigation (no reload) — audio still auto-plays as before