### PR TITLE
feat: long-press Escape to exit story mode

### DIFF
--- a/src/views/StoryView.vue
+++ b/src/views/StoryView.vue
@@ -419,14 +419,25 @@ function togglePause() {
   }
 }
 
-// Spacebar
+// Keyboard controls
 function handleKeydown(e) {
+  if (e.code === 'Escape' && !e.repeat) {
+    e.preventDefault()
+    startExit()
+    return
+  }
   if (e.code !== 'Space') return
   const tag = e.target.tagName
   if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return
   e.preventDefault()
   if (state.value === 'narrating') {
     togglePause()
+  }
+}
+
+function handleKeyup(e) {
+  if (e.code === 'Escape') {
+    cancelExit()
   }
 }
 
@@ -612,11 +623,13 @@ function goToOverview() {
 
 onMounted(() => {
   document.addEventListener('keydown', handleKeydown)
+  document.addEventListener('keyup', handleKeyup)
   loadAndStart()
 })
 
 onUnmounted(() => {
   document.removeEventListener('keydown', handleKeydown)
+  document.removeEventListener('keyup', handleKeyup)
   clearAutoAdvance()
   cancelExit()
   cleanup()


### PR DESCRIPTION
## Summary

- Long-press Escape key (2s) exits story mode, same as the X button
- Progress ring animates on the X button during the hold
- Releasing before 2s cancels the exit
- Key repeat events are ignored to prevent retriggering

## Test plan

- [ ] Hold Escape for 2s — exits to lessons overview
- [ ] Hold Escape briefly and release — stays in story mode
- [ ] X button still works as before
- [ ] Spacebar still toggles pause