### PR TITLE
fix: allow back navigation and play question audio during assessments

### DIFF
--- a/src/views/StoryView.vue
+++ b/src/views/StoryView.vue
@@ -367,6 +367,7 @@ function showCurrentExample() {
     // Show text input (with answers array + goto_wrong support)
     state.value = 'input'
     clearAutoAdvance()
+    if (!paused.value) playCurrentAudio()
     nextTick(() => { inputRef.value?.focus() })
     return
   }


### PR DESCRIPTION
## Summary

- Tapping the left side during an assessment (select/multiple-choice/input) now goes back to the previous example
- Assessment questions now play their audio (e.g. "Wohin soll Mila gehen?")
- Auto-advance is safely skipped since it checks for `state === 'narrating'`

## Test plan

- [ ] In story mode, reach an assessment — question audio plays
- [ ] Tap left side of screen during assessment — goes back
- [ ] Tap right side during assessment — does nothing (no skip)
- [ ] Normal narration left/right navigation still works