### PR TITLE
feat: add Linux and Docker to default workshop sources

### DIFF
--- a/public/default-sources.yaml
+++ b/public/default-sources.yaml
@@ -4,3 +4,5 @@ sources:
   - https://open-learn.app/workshop-portugiesisch/index.yaml
   - https://open-learn.app/workshop-farsi/index.yaml
   - https://open-learn.app/workshop-arabisch/index.yaml
+  - https://open-learn.app/workshop-linux-grundlagen/index.yaml
+  - https://open-learn.app/workshop-docker/index.yaml


### PR DESCRIPTION
## Summary
- Add `workshop-linux-grundlagen` and `workshop-docker` to `default-sources.yaml`
- Users will see these workshops automatically on the landing page

## Dependencies
Merge after the workshop repos have Pages enabled and are deployed:
- openlearnapp/workshop-linux-grundlagen#1
- openlearnapp/workshop-docker#1