### PR TITLE
fix: remove dev SSL and update E2E tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-03-24
+
+### Fixes
+
+- Remove SSL from local dev server — dev now runs HTTP, matching Playwright and CI expectations
+- Remove unused `@vitejs/plugin-basic-ssl` dependency
+
+### Fixes
+
+- Fix 6 failing E2E tests: update selectors and URLs to match current UI (home page language buttons, settings button, workshop URLs, footer links)
+
 ## 2026-03-19
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@playwright/test": "^1.40.0",
     "@tailwindcss/typography": "^0.5.19",
-    "@vitejs/plugin-basic-ssl": "^2.1.0",
     "@vitejs/plugin-vue": "^5.0.0",
     "@vitest/ui": "1.6.1",
     "autoprefixer": "^10.4.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@3.4.18)
-      '@vitejs/plugin-basic-ssl':
-        specifier: ^2.1.0
-        version: 2.1.0(vite@5.4.21(@types/node@20.19.25))
       '@vitejs/plugin-vue':
         specifier: ^5.0.0
         version: 5.2.4(vite@5.4.21(@types/node@20.19.25))(vue@3.5.24)
@@ -511,12 +508,6 @@ packages:
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
-
-  '@vitejs/plugin-basic-ssl@2.1.0':
-    resolution: {integrity: sha512-dOxxrhgyDIEUADhb/8OlV9JIqYLgos03YorAueTIeOUskLJSEsfwCByjbu98ctXitUN3znXKp0bYD/WHSudCeA==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    peerDependencies:
-      vite: ^6.0.0 || ^7.0.0
 
   '@vitejs/plugin-vue@5.2.4':
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
@@ -1803,10 +1794,6 @@ snapshots:
   '@types/web-bluetooth@0.0.20': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
-
-  '@vitejs/plugin-basic-ssl@2.1.0(vite@5.4.21(@types/node@20.19.25))':
-    dependencies:
-      vite: 5.4.21(@types/node@20.19.25)
 
   '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@20.19.25))(vue@3.5.24)':
     dependencies:

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -11,18 +11,18 @@ test.describe('Open Learn App', () => {
     });
 
     await page.goto('/');
-    
+
     // Wait a bit for the page to load
     await page.waitForTimeout(2000);
-    
+
     // Check if there are any console errors
     if (errors.length > 0) {
       console.log('Console errors:', errors);
     }
-    
+
     // Check that the page title is set
     await expect(page).toHaveTitle('Open Learn');
-    
+
     // Check that the app div exists
     const app = page.locator('#app');
     await expect(app).toBeAttached();
@@ -31,28 +31,27 @@ test.describe('Open Learn App', () => {
   test('should have the correct HTML structure', async ({ page }) => {
     await page.goto('/');
     await page.waitForTimeout(1000);
-    
+
     // Check if body has the expected classes
     const body = page.locator('body');
     await expect(body).toHaveClass(/bg-gradient-to-br/);
   });
 
   test('should toggle dark mode on and off correctly', async ({ page }) => {
-    await page.goto('/');
+    // Navigate to a workshop page first, then open settings
+    await page.goto('/#/english/open-learn-guide/lessons');
     await page.waitForTimeout(1000);
 
     // Open settings
-    const settingsButton = page.locator('button[title="Settings"]');
-    await settingsButton.click();
+    await page.getByRole('button', { name: 'Settings' }).click();
     await page.waitForTimeout(500);
 
-    // Verify dark mode is initially off (check html element, not body)
+    // Verify dark mode is initially off
     const html = page.locator('html');
     await expect(html).not.toHaveClass(/dark/);
 
-    // Find the Dark Mode toggle by finding the label that contains "Dark Mode" text
-    // then finding its associated toggle label
-    const darkModeToggle = page.locator('text=Dark Mode').locator('..').locator('..').locator('button[role="switch"]');
+    // Find the Dark Mode toggle switch
+    const darkModeToggle = page.getByRole('switch').first();
     await darkModeToggle.click();
     await page.waitForTimeout(500);
 
@@ -68,20 +67,20 @@ test.describe('Open Learn App', () => {
   });
 
   test('should persist dark mode setting after reload', async ({ page }) => {
-    await page.goto('/');
+    // Navigate to a workshop page first, then open settings
+    await page.goto('/#/english/open-learn-guide/lessons');
     await page.waitForTimeout(1000);
 
     // Open settings and enable dark mode
-    const settingsButton = page.locator('button[title="Settings"]');
-    await settingsButton.click();
+    await page.getByRole('button', { name: 'Settings' }).click();
     await page.waitForTimeout(500);
 
-    // Find the Dark Mode toggle
-    const darkModeToggle = page.locator('text=Dark Mode').locator('..').locator('..').locator('button[role="switch"]');
+    // Find the Dark Mode toggle switch
+    const darkModeToggle = page.getByRole('switch').first();
     await darkModeToggle.click();
     await page.waitForTimeout(500);
 
-    // Verify dark mode is enabled (check html element, not body)
+    // Verify dark mode is enabled
     const html = page.locator('html');
     await expect(html).toHaveClass(/dark/);
 

--- a/tests/e2e/home.spec.js
+++ b/tests/e2e/home.spec.js
@@ -9,27 +9,24 @@ test.describe('Home Page', () => {
     // Should show the tagline
     await expect(page.getByText('Learn anything')).toBeVisible();
 
-    // Should show language buttons
+    // Should show Deutsch language button and Browse workshops link
     await expect(page.getByText('Deutsch', { exact: false })).toBeVisible();
-    await expect(page.getByText('English', { exact: false })).toBeVisible();
-
-    // Should NOT show navbar (hidden on home page)
-    await expect(page.locator('[aria-label="Settings"]')).not.toBeVisible();
+    await expect(page.getByRole('link', { name: 'Browse workshops' })).toBeVisible();
   });
 
   test('should navigate to workshop overview on language click', async ({ page }) => {
     await page.goto('/');
     await page.waitForTimeout(1000);
 
-    // Click English language button
-    await page.getByText('English', { exact: false }).click();
+    // Click Browse workshops link
+    await page.getByRole('link', { name: 'Browse workshops' }).click();
     await page.waitForTimeout(1000);
 
     // Should navigate to workshop overview
-    await expect(page).toHaveURL(/#\/english\/workshops/);
+    await expect(page).toHaveURL(/#\/deutsch/);
 
     // Should show workshop tiles
-    await expect(page.getByText('Open Learn Guide')).toBeVisible();
+    await expect(page.getByText('Open Learn Anleitung')).toBeVisible();
 
     // Clean up
     await page.evaluate(() => localStorage.clear());
@@ -39,11 +36,11 @@ test.describe('Home Page', () => {
 test.describe('Workshop Overview', () => {
 
   test('should show workshops and language dropdown', async ({ page }) => {
-    await page.goto('/#/english/workshops');
-    await page.waitForTimeout(1000);
+    await page.goto('/#/english');
+    await page.waitForTimeout(2000);
 
     // Should show language dropdown in navbar
-    const dropdown = page.locator('[aria-label="Change language"]');
+    const dropdown = page.getByRole('button', { name: 'Change language' });
     await expect(dropdown).toBeVisible();
 
     // Should show workshop tiles
@@ -52,8 +49,8 @@ test.describe('Workshop Overview', () => {
   });
 
   test('should navigate to lessons on workshop click', async ({ page }) => {
-    await page.goto('/#/english/workshops');
-    await page.waitForTimeout(1000);
+    await page.goto('/#/english');
+    await page.waitForTimeout(2000);
 
     // Click on workshop tile
     await page.getByText('Open Learn Guide').click();
@@ -64,18 +61,18 @@ test.describe('Workshop Overview', () => {
   });
 
   test('should switch language via dropdown', async ({ page }) => {
-    await page.goto('/#/english/workshops');
-    await page.waitForTimeout(1000);
+    await page.goto('/#/english');
+    await page.waitForTimeout(2000);
 
-    // Switch to Deutsch using precise dropdown selector
-    await page.locator('[aria-label="Change language"]').click();
+    // Switch to Deutsch using dropdown
+    await page.getByRole('button', { name: 'Change language' }).click();
     await page.waitForTimeout(300);
     const dropdown = page.locator('.absolute.top-full');
     await dropdown.getByText('Deutsch').click();
     await page.waitForTimeout(500);
 
     // Should navigate to deutsch workshops
-    await expect(page).toHaveURL(/#\/deutsch\/workshops/);
+    await expect(page).toHaveURL(/#\/deutsch/);
     await expect(page.getByText('Open Learn Anleitung')).toBeVisible();
 
     // Clean up
@@ -83,12 +80,12 @@ test.describe('Workshop Overview', () => {
   });
 
   test('should show info links', async ({ page }) => {
-    await page.goto('/#/english/workshops');
-    await page.waitForTimeout(1000);
+    await page.goto('/#/english');
+    await page.waitForTimeout(2000);
 
-    // Should show Guide, Feedback, and Bug Report links
-    await expect(page.getByText('Guide & First Steps')).toBeVisible();
-    await expect(page.getByText('Give Feedback')).toBeVisible();
-    await expect(page.getByText('Report a Bug')).toBeVisible();
+    // Should show footer links
+    await expect(page.getByRole('link', { name: 'Guide' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Feedback' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Bug Report' })).toBeVisible();
   });
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,17 +1,13 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
-import basicSsl from '@vitejs/plugin-basic-ssl'
 import path from 'path'
 
 export default defineConfig(({ command }) => ({
   plugins: [
     vue(),
-    // Only use SSL in dev mode, not for preview/build
-    ...(command === 'serve' && !process.env.CI ? [basicSsl()] : [])
   ],
   base: '/',
   server: {
-    https: command === 'serve' && !process.env.CI,
     cors: true  // Enable CORS for cross-origin requests
   },
   preview: {


### PR DESCRIPTION
## Summary
- Remove `@vitejs/plugin-basic-ssl` — dev server now runs HTTP instead of self-signed HTTPS
- Fix 6 failing E2E tests with stale selectors that didn't match the current UI
- All 31 E2E tests pass locally

## What changed
- **vite.config.js**: Removed `basicSsl` plugin and `https` server option (GitHub Pages handles HTTPS in production)
- **tests/e2e/app.spec.js**: Dark mode tests navigate to workshop page first (settings button not on home), use `getByRole('switch')` for toggle
- **tests/e2e/home.spec.js**: Updated language buttons, workshop URLs (`/#/english` not `/#/english/workshops`), footer link text, dropdown selector

## Test plan
- [x] `npx playwright test` — 31 passed, 0 failed (15.6s)
- [ ] Verify `pnpm dev` starts on HTTP
- [ ] Verify GitHub Pages deployment still works with HTTPS