### PR TITLE
feat: add all workshops to default sources

### DIFF
--- a/public/default-sources.yaml
+++ b/public/default-sources.yaml
@@ -6,3 +6,6 @@ sources:
   - https://open-learn.app/workshop-arabisch/index.yaml
   - https://open-learn.app/workshop-linux-grundlagen/index.yaml
   - https://open-learn.app/workshop-docker/index.yaml
+  - https://open-learn.app/workshop-english/index.yaml
+  - https://open-learn.app/workshop-spanisch/index.yaml
+  - https://open-learn.app/workshop-AI-im-Journalismus/index.yaml


### PR DESCRIPTION
## Summary
- Add English, Spanisch, and AI-im-Journalismus to `default-sources.yaml`
- All 8 workshops are now automatically available to users

## All default sources after merge
1. workshop-portugiesisch
2. workshop-farsi
3. workshop-arabisch
4. workshop-linux-grundlagen
5. workshop-docker
6. workshop-english
7. workshop-spanisch
8. workshop-AI-im-Journalismus