### PR TITLE
fix: lesson images not loading for remote workshops

### DIFF
--- a/src/components/LessonCard.vue
+++ b/src/components/LessonCard.vue
@@ -1,58 +1,85 @@
 <template>
   <div
     :class="[
-      'group relative rounded-2xl border-2 transition-all duration-300 cursor-pointer overflow-hidden',
-      'hover:scale-[1.02] hover:shadow-xl',
+      'group relative rounded-xl border transition-all duration-200 cursor-pointer overflow-hidden',
       isNext
-        ? 'border-primary shadow-lg shadow-primary/20 bg-gradient-to-br from-primary/10 via-primary/5 to-transparent dark:from-primary/20 dark:via-primary/10 dark:to-slate-900'
+        ? 'border-primary shadow-lg shadow-primary/10 bg-primary/5 dark:bg-primary/10'
         : isCompleted
-          ? 'border-green-400 dark:border-green-500 bg-gradient-to-br from-green-50 to-green-100/50 dark:from-green-950/60 dark:to-slate-900'
-          : 'border-border/50 hover:border-primary/50 bg-gradient-to-br from-white to-slate-50 dark:from-slate-800 dark:to-slate-900 dark:border-slate-700/60 dark:hover:border-primary/50'
+          ? 'border-green-400 dark:border-green-500 bg-green-50 dark:bg-green-950/40'
+          : 'border-border hover:border-primary/40 hover:shadow-md bg-card'
     ]"
     @click="$emit('open', lesson.number)">
 
-    <!-- Header Image Banner -->
-    <div v-if="imageUrl" class="relative w-full h-32 sm:h-36 overflow-hidden">
-      <img
-        :src="imageUrl"
-        :alt="lesson.title"
-        class="w-full h-full object-cover" />
-      <div class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent"></div>
-      <!-- Lesson number overlay -->
-      <div class="absolute bottom-3 left-4 flex items-center gap-2">
-        <span :class="[
-          'text-2xl font-black drop-shadow-lg',
-          isCompleted ? 'text-green-300' : 'text-white'
-        ]">{{ lesson.number }}</span>
-        <span v-if="isNext" class="text-xs font-semibold px-2.5 py-1 rounded-full bg-primary text-primary-foreground shadow-md">
-          {{ nextLabel }}
-        </span>
+    <!-- Top row: Thumbnail + Main info -->
+    <div class="flex items-stretch">
+      <!-- Thumbnail -->
+      <div v-if="lesson.image" class="w-24 sm:w-32 flex-shrink-0 overflow-hidden">
+        <img
+          :src="imageUrl"
+          :alt="lesson.title"
+          class="w-full h-full object-cover" />
       </div>
-      <!-- Actions overlay -->
-      <div class="absolute top-2 right-2 flex gap-1">
+
+      <!-- Content -->
+      <div class="flex-1 p-4 min-w-0">
+        <div class="flex items-start gap-3">
+          <!-- Lesson number -->
+          <div :class="[
+            'text-2xl font-bold flex-shrink-0 leading-none mt-0.5',
+            isNext ? 'text-primary' : isCompleted ? 'text-green-600 dark:text-green-400' : 'text-primary/70'
+          ]">
+            {{ lesson.number }}
+          </div>
+
+          <!-- Title + description -->
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2">
+              <h3 :class="[
+                'text-base font-semibold truncate',
+                isCompleted ? 'text-green-700 dark:text-green-300' : 'text-foreground'
+              ]">
+                {{ lesson.title }}
+              </h3>
+              <!-- Next lesson badge -->
+              <span v-if="isNext" class="flex-shrink-0 text-xs font-semibold px-2 py-0.5 rounded-full bg-primary text-primary-foreground">
+                {{ nextLabel }}
+              </span>
+            </div>
+            <p v-if="lesson.description" class="text-sm text-muted-foreground mt-0.5 line-clamp-2">
+              {{ lesson.description }}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Actions (right side) -->
+      <div class="flex flex-col items-center justify-center gap-1 px-3 flex-shrink-0">
+        <!-- Favorite toggle -->
         <button
           @click.stop="$emit('toggle-favorite', lesson.number)"
           :title="isFavorite ? removeFavoriteLabel : addFavoriteLabel"
           :class="[
-            'p-1.5 rounded-full backdrop-blur-sm transition-colors',
+            'p-1.5 rounded-lg transition-colors',
             isFavorite
-              ? 'text-amber-400 bg-black/30'
-              : 'text-white/50 bg-black/20 hover:text-amber-400'
+              ? 'text-amber-500 hover:text-amber-600'
+              : 'text-muted-foreground/30 hover:text-amber-400'
           ]">
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" :fill="isFavorite ? 'currentColor' : 'none'" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" :fill="isFavorite ? 'currentColor' : 'none'" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
           </svg>
         </button>
+
+        <!-- Completed toggle -->
         <button
           @click.stop="$emit('toggle-completed', lesson.number)"
           :title="isCompleted ? markIncompleteLabel : markCompleteLabel"
           :class="[
-            'p-1.5 rounded-full backdrop-blur-sm transition-colors',
+            'p-1.5 rounded-lg transition-colors',
             isCompleted
-              ? 'text-green-400 bg-black/30'
-              : 'text-white/50 bg-black/20 hover:text-green-400'
+              ? 'text-green-500 hover:text-green-600'
+              : 'text-muted-foreground/30 hover:text-green-400'
           ]">
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path v-if="isCompleted" d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
             <polyline v-if="isCompleted" points="22 4 12 14.01 9 11.01" />
             <circle v-else cx="12" cy="12" r="10" />
@@ -61,42 +88,8 @@
       </div>
     </div>
 
-    <!-- No-image fallback: number + actions inline -->
-    <div v-else class="flex items-center justify-between px-4 pt-4">
-      <div class="flex items-center gap-2">
-        <span :class="[
-          'text-2xl font-black',
-          isNext ? 'text-primary' : isCompleted ? 'text-green-600 dark:text-green-400' : 'text-primary/60'
-        ]">{{ lesson.number }}</span>
-        <span v-if="isNext" class="text-xs font-semibold px-2.5 py-1 rounded-full bg-primary text-primary-foreground">
-          {{ nextLabel }}
-        </span>
-      </div>
-      <div class="flex gap-1">
-        <button @click.stop="$emit('toggle-favorite', lesson.number)" :class="['p-1.5 rounded-lg transition-colors', isFavorite ? 'text-amber-500' : 'text-muted-foreground/30 hover:text-amber-400']">
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" :fill="isFavorite ? 'currentColor' : 'none'" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" /></svg>
-        </button>
-        <button @click.stop="$emit('toggle-completed', lesson.number)" :class="['p-1.5 rounded-lg transition-colors', isCompleted ? 'text-green-500' : 'text-muted-foreground/30 hover:text-green-400']">
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path v-if="isCompleted" d="M22 11.08V12a10 10 0 1 1-5.93-9.14" /><polyline v-if="isCompleted" points="22 4 12 14.01 9 11.01" /><circle v-else cx="12" cy="12" r="10" /></svg>
-        </button>
-      </div>
-    </div>
-
-    <!-- Title + description -->
-    <div class="px-4 pt-3">
-      <h3 :class="[
-        'text-base font-bold leading-tight',
-        isCompleted ? 'text-green-700 dark:text-green-300' : 'text-foreground'
-      ]">
-        {{ lesson.title }}
-      </h3>
-      <p v-if="lesson.description" class="text-sm text-muted-foreground mt-1 line-clamp-2">
-        {{ lesson.description }}
-      </p>
-    </div>
-
     <!-- Bottom row: Stats + Labels -->
-    <div class="px-4 pb-3 pt-2">
+    <div class="px-4 pb-3 pt-0">
       <!-- Stats row -->
       <div class="flex items-center gap-3 text-xs text-muted-foreground">
         <!-- Sections -->


### PR DESCRIPTION
## Problem
Lesson header images in remote workshops show as broken alt-text placeholders.
The `resolveLessonImage` function only handled `_source.type === 'url'` but remote
workshop lessons come as folder-type sources where `_source.path` is just the
folder name, not a full URL.

## Fix
When the workshop itself resolves to a URL (remote), use that URL as the base
for constructing the lesson image path.

## Test
1. `pnpm dev`
2. Open any remote workshop (e.g. Linux Grundlagen)
3. Lesson cards should show SVG header images instead of alt-text