### PR TITLE
fix: learning path left-aligned — full-width cards (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-03-26
+
+### Fixes
+
+- Learning path: move path line to left side on all screen sizes — cards use full width instead of alternating left/right (#93)
+
 ## 2026-03-25
 
 ### Features
@@ -12,8 +18,7 @@
 - Add next lesson highlighting with "Continue" badge
 - Completed lessons appear at bottom, visually dimmed
 - Path nodes with status indicators (empty/dot/checkmark)
-- Desktop: cards alternate left/right of path line
-- Mobile: path line left, cards right
+- Path line always on left, cards always right — consistent on all screen sizes
 - i18n: all new strings in DE, EN, FA, AR
 - 7 new E2E tests for learning path functionality
 

--- a/docs/lesson-overview-plan.md
+++ b/docs/lesson-overview-plan.md
@@ -88,8 +88,7 @@ Getrennt von bestehendem `progress` (Item-Level) um keine Migration zu brauchen.
 
 **LearningPath.vue:**
 - Vertikale Linie (CSS) mit Knotenpunkten pro Lektion
-- Desktop: Karten alternierend links/rechts vom Pfad
-- Mobile: Linie links, Karten rechts
+- Linie immer links, Karten immer rechts — auf allen Bildschirmgrößen gleich
 - Erledigte Pfad-Abschnitte: ausgefüllte Linie (primary, sanfter Gradient)
 - Offene Abschnitte: gestrichelte graue Linie
 - Knotenpunkte: Kreis mit Status-Farbe (grau/blau/grün)

--- a/specs/lesson-overview.md
+++ b/specs/lesson-overview.md
@@ -92,7 +92,7 @@ Neue Daten in localStorage:
 
 ## Entscheidungen
 
-1. **Grafischer Pfad**: Ja — eine vertikale Linie verbindet die Lektionen visuell. Erledigte Abschnitte der Linie sind farbig ausgefüllt (primary color, sanfter Gradient), offene Abschnitte gestrichelt/grau. An jedem Knotenpunkt sitzt ein Kreis-Indikator (offen/besucht/erledigt). Karten liegen abwechselnd links und rechts des Pfads (Desktop) für ein modernes, aufgeräumtes Layout. Auf Mobile: Linie links, Karten rechts. Der Stil ist clean und minimalistisch — keine Spielelemente, sondern ein eleganter visueller Fortschrittsindikator.
+1. **Grafischer Pfad**: Ja — eine vertikale Linie verbindet die Lektionen visuell. Erledigte Abschnitte der Linie sind farbig ausgefüllt (primary color, sanfter Gradient), offene Abschnitte gestrichelt/grau. An jedem Knotenpunkt sitzt ein Kreis-Indikator (offen/besucht/erledigt). Die Linie verläuft durchgehend links, Karten liegen rechts davon — auf allen Bildschirmgrößen gleich. Das vermeidet leeren Raum und nutzt die volle Breite für die Karten. Der Stil ist clean und minimalistisch — keine Spielelemente, sondern ein eleganter visueller Fortschrittsindikator.
 2. **Fortschrittsbalken**: Ja — oben auf der Seite wird der Gesamtfortschritt angezeigt (z.B. "4/10 Lektionen erledigt" mit visueller Leiste).
 3. **Drag & Drop**: Ja — Favoriten können per Drag & Drop umsortiert werden. Touch-Support (long press → drag) für Mobile. Reihenfolge wird in localStorage gespeichert.
 

--- a/src/components/LearningPath.vue
+++ b/src/components/LearningPath.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative">
-    <!-- Vertical path line (center on desktop, left on mobile) -->
-    <div class="absolute top-0 bottom-0 left-5 sm:left-1/2 sm:-translate-x-px w-0.5">
+    <!-- Vertical path line (always left) -->
+    <div class="absolute top-0 bottom-0 left-5 w-0.5">
       <!-- Background line (full height, dashed for incomplete) -->
       <div class="absolute inset-0 border-l-2 border-dashed border-muted-foreground/20"></div>
       <!-- Completed portion (solid, gradient) -->
@@ -15,19 +15,13 @@
     <!-- Lesson nodes -->
     <div class="relative space-y-6">
       <div
-        v-for="(lesson, index) in sortedLessons"
+        v-for="lesson in sortedLessons"
         :key="lesson.number"
-        :class="[
-          'relative flex items-start gap-4',
-          // Desktop: alternate left/right
-          'sm:gap-0',
-          index % 2 === 0 ? 'sm:flex-row' : 'sm:flex-row-reverse'
-        ]">
+        class="relative flex items-start gap-4">
 
         <!-- Node dot -->
         <div :class="[
           'relative z-10 flex-shrink-0 w-10 h-10 rounded-full border-2 flex items-center justify-center transition-all duration-300',
-          'sm:absolute sm:left-1/2 sm:-translate-x-1/2',
           getNodeClass(lesson)
         ]">
           <!-- Completed checkmark -->
@@ -43,12 +37,7 @@
         </div>
 
         <!-- Card -->
-        <div :class="[
-          'flex-1 ml-2',
-          // Desktop positioning
-          'sm:ml-0',
-          index % 2 === 0 ? 'sm:mr-[calc(50%+1.5rem)] sm:pr-0' : 'sm:ml-[calc(50%+1.5rem)] sm:pl-0'
-        ]">
+        <div class="flex-1">
           <!-- Drag handle for favorites -->
           <div class="flex items-center gap-1">
             <div


### PR DESCRIPTION
## Summary
- Lernpfad-Linie jetzt durchgehend links statt mittig mit alternierenden Karten
- Karten nutzen die volle Breite — kein leerer Platz mehr
- Gleiches Layout auf Desktop und Mobile

## Geänderte Dateien
- `specs/lesson-overview.md` — Spec aktualisiert
- `docs/lesson-overview-plan.md` — Dev-Plan aktualisiert
- `src/components/LearningPath.vue` — Layout vereinfacht
- `CHANGELOG.md` — Eintrag hinzugefügt

## Test plan
- [ ] `pnpm dev` → Workshop öffnen → Lektionsübersicht: Pfad links, Karten rechts
- [ ] Desktop: Karten nutzen volle Breite (kein Wechsel links/rechts)
- [ ] Mobile: Layout unverändert (war schon links)
- [ ] Fortschrittsbalken, Favoriten, Status-Markierung funktionieren weiterhin