### PR TITLE
fix: resolve lesson paths for built-in workshop-* sources

### DIFF
--- a/src/composables/useLessons.js
+++ b/src/composables/useLessons.js
@@ -478,14 +478,14 @@ export function useLessons() {
 
       // Construct lessons.yaml URL
       let lessonsUrl
-      if (resolvedWorkshop.startsWith('http://') || resolvedWorkshop.startsWith('https://')) {
-        // Workshop is a URL (resolved from slug or direct)
+      if (resolvedWorkshop !== workshop) {
+        // Workshop was resolved from slug map (remote or built-in workshop-* source)
         lessonsUrl = `${resolvedWorkshop}/lessons.yaml`
       } else if (lang.startsWith('http://') || lang.startsWith('https://')) {
         // Language is a URL, workshop is a folder
         lessonsUrl = `${lang}/${workshop}/lessons.yaml`
       } else {
-        // Both are folders
+        // Both are local folders under lessons/
         lessonsUrl = `lessons/${lang}/${workshop}/lessons.yaml`
       }
 
@@ -528,14 +528,14 @@ export function useLessons() {
       if (source.type === 'url') {
         // Lesson is a URL
         lessonPath = `${source.path}/content.yaml`
-      } else if (resolvedWorkshop.startsWith('http://') || resolvedWorkshop.startsWith('https://')) {
-        // Workshop is a URL (resolved from slug), lesson is a folder
+      } else if (resolvedWorkshop !== workshop) {
+        // Workshop was resolved from slug map (remote or built-in workshop-* source)
         lessonPath = `${resolvedWorkshop}/${source.path}/content.yaml`
       } else if (lang.startsWith('http://') || lang.startsWith('https://')) {
         // Language is a URL, others are folders
         lessonPath = `${lang}/${workshop}/${source.path}/content.yaml`
       } else {
-        // All are folders
+        // All are local folders under lessons/
         lessonPath = `lessons/${lang}/${workshop}/${source.path}/content.yaml`
       }
 

--- a/tests/lessons.test.js
+++ b/tests/lessons.test.js
@@ -185,6 +185,91 @@ describe('useLessons', () => {
     })
   })
 
+  describe('loadLessonsForWorkshop', () => {
+    it('uses lessons/ prefix for plain folder workshops', async () => {
+      lessons.availableContent.value = { 'deutsch': { 'open-learn-guide': [] } }
+
+      const originalFetch = globalThis.fetch
+      const fetchCalls = []
+      globalThis.fetch = vi.fn().mockImplementation((url) => {
+        fetchCalls.push(url)
+        if (url.endsWith('lessons.yaml')) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve('lessons:\n  - 01-welcome\n  - 02-basics')
+          })
+        }
+        return Promise.resolve({ ok: false, status: 404 })
+      })
+
+      await lessons.loadLessonsForWorkshop('deutsch', 'open-learn-guide')
+      expect(fetchCalls[0]).toBe('lessons/deutsch/open-learn-guide/lessons.yaml')
+
+      globalThis.fetch = originalFetch
+    })
+
+    it('uses resolved URL for workshop registered via content source', async () => {
+      const originalFetch = globalThis.fetch
+      const fetchCalls = []
+
+      // Mock all fetches needed for loadAvailableContent + loadContentSource
+      globalThis.fetch = vi.fn().mockImplementation((url) => {
+        fetchCalls.push(url)
+        // Main index.yaml
+        if (url === 'lessons/index.yaml') {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve('languages:\n  - folder: deutsch\n    code: de-DE')
+          })
+        }
+        // default-sources.yaml with a relative built-in workshop
+        if (url === 'default-sources.yaml') {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve('sources:\n  - workshop-my-topic/index.yaml')
+          })
+        }
+        // Workshop index.yaml
+        if (url === 'workshop-my-topic/index.yaml') {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve('languages:\n  - folder: deutsch\n    code: de-DE')
+          })
+        }
+        // Workshop workshops.yaml
+        if (url === 'workshop-my-topic/deutsch/workshops.yaml') {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve('workshops:\n  - folder: my-topic\n    code: de-DE\n    title: My Topic')
+          })
+        }
+        // Lessons list
+        if (url === 'workshop-my-topic/deutsch/my-topic/lessons.yaml') {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve('lessons:\n  - 01-intro\n  - 02-basics')
+          })
+        }
+        return Promise.resolve({ ok: false, status: 404 })
+      })
+
+      // Load everything to populate slug map
+      await lessons.loadAvailableContent()
+
+      // Verify slug map was populated
+      const resolved = lessons.resolveWorkshopKey('deutsch', 'my-topic')
+      expect(resolved).toBe('workshop-my-topic/deutsch/my-topic')
+
+      fetchCalls.length = 0
+
+      // Load lessons — should use resolved path, not lessons/ prefix
+      await lessons.loadLessonsForWorkshop('deutsch', 'my-topic')
+      expect(fetchCalls[0]).toBe('workshop-my-topic/deutsch/my-topic/lessons.yaml')
+
+      globalThis.fetch = originalFetch
+    })
+  })
+
   describe('loadLesson', () => {
     it('parses lesson content.yaml', async () => {
       const originalFetch = globalThis.fetch
@@ -210,6 +295,58 @@ describe('useLessons', () => {
 
       const lesson = await lessons.loadLesson('deutsch', 'portugiesisch', '01-test')
       expect(lesson).toBeNull()
+
+      globalThis.fetch = originalFetch
+    })
+
+    it('uses resolved slug map URL for lesson content', async () => {
+      const originalFetch = globalThis.fetch
+      const fetchCalls = []
+
+      // Mock full loading flow to populate slug map
+      globalThis.fetch = vi.fn().mockImplementation((url) => {
+        fetchCalls.push(url)
+        if (url === 'lessons/index.yaml') {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve('languages:\n  - folder: deutsch\n    code: de-DE')
+          })
+        }
+        if (url === 'default-sources.yaml') {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve('sources:\n  - workshop-my-topic/index.yaml')
+          })
+        }
+        if (url === 'workshop-my-topic/index.yaml') {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve('languages:\n  - folder: deutsch\n    code: de-DE')
+          })
+        }
+        if (url === 'workshop-my-topic/deutsch/workshops.yaml') {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve('workshops:\n  - folder: my-topic\n    code: de-DE')
+          })
+        }
+        if (url === 'workshop-my-topic/deutsch/my-topic/01-intro/content.yaml') {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve('number: 1\ntitle: Test\nsections: []')
+          })
+        }
+        return Promise.resolve({ ok: false, status: 404 })
+      })
+
+      await lessons.loadAvailableContent()
+      fetchCalls.length = 0
+
+      const lesson = await lessons.loadLesson('deutsch', 'my-topic', '01-intro')
+      expect(lesson).not.toBeNull()
+      expect(lesson.title).toBe('Test')
+      // Should fetch from resolved workshop path, not lessons/ prefix
+      expect(fetchCalls[0]).toBe('workshop-my-topic/deutsch/my-topic/01-intro/content.yaml')
 
       globalThis.fetch = originalFetch
     })


### PR DESCRIPTION
<![CDATA[## Summary

- After the workshop-* structure refactor (#107), built-in workshops registered via `default-sources.yaml` got relative paths in the slug map (e.g. `workshop-open-learn-guide/deutsch/open-learn-guide`). The URL construction in `loadLessonsForWorkshop` and `loadLesson` only checked for `http(s)://` URLs, so relative slug map paths fell through to the wrong `lessons/` prefix path.
- Fix: check `resolvedWorkshop !== workshop` instead of checking for http prefix, so any slug-mapped workshop uses the resolved path directly.
- Added 3 integration tests verifying correct URL construction for slug-mapped workshops (lessons list + lesson content).

## Test plan

- [x] All 138 unit tests pass (135 existing + 3 new)
- [x] Production build succeeds
- [ ] Verify built-in workshops (open-learn-guide, open-learn-feedback, milas-abenteuer) load lessons correctly in browser

https://claude.ai/code/session_01AjdrwWDXGRGeKZWn5HQmCH]]>