### PR TITLE
feat: PWA install for full app vs single workshop

### DIFF
--- a/src/composables/useManifest.js
+++ b/src/composables/useManifest.js
@@ -1,0 +1,69 @@
+import { ref, computed } from 'vue'
+
+const DEFAULT_MANIFEST = {
+  name: 'Open Learn',
+  short_name: 'Open Learn',
+  description: 'Learn any workshop by examples — offline capable',
+  start_url: '/',
+  display: 'standalone',
+  background_color: '#000000',
+  theme_color: '#000000',
+  icons: [{ src: '/favicon.svg', sizes: 'any', type: 'image/svg+xml' }]
+}
+
+// Current active manifest (reactive)
+const currentManifest = ref({ ...DEFAULT_MANIFEST })
+let blobUrl = null
+
+function applyManifest(manifest) {
+  // Clean up previous blob
+  if (blobUrl) URL.revokeObjectURL(blobUrl)
+
+  currentManifest.value = manifest
+  const blob = new Blob([JSON.stringify(manifest)], { type: 'application/json' })
+  blobUrl = URL.createObjectURL(blob)
+
+  let link = document.querySelector('link[rel="manifest"]')
+  if (!link) {
+    link = document.createElement('link')
+    link.rel = 'manifest'
+    document.head.appendChild(link)
+  }
+  link.href = blobUrl
+}
+
+/**
+ * Set manifest for a single workshop install
+ */
+function setWorkshopManifest(workshopTitle, language, workshop) {
+  applyManifest({
+    name: workshopTitle,
+    short_name: workshopTitle,
+    description: `${workshopTitle} — Open Learn workshop`,
+    start_url: `/#/${language}/${workshop}/lessons`,
+    display: 'standalone',
+    background_color: '#000000',
+    theme_color: '#000000',
+    icons: [{ src: '/favicon.svg', sizes: 'any', type: 'image/svg+xml' }]
+  })
+}
+
+/**
+ * Restore the default full-app manifest
+ */
+function setDefaultManifest() {
+  applyManifest({ ...DEFAULT_MANIFEST })
+}
+
+const isFullApp = computed(() => currentManifest.value.start_url === '/')
+const manifestName = computed(() => currentManifest.value.name)
+
+export function useManifest() {
+  return {
+    currentManifest,
+    manifestName,
+    isFullApp,
+    setWorkshopManifest,
+    setDefaultManifest
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import { useSettings } from './composables/useSettings'
 import { useProgress } from './composables/useProgress'
 import { useAssessments } from './composables/useAssessments'
 import { useGun } from './composables/useGun'
+import { useManifest } from './composables/useManifest'
 
 // Initialize and load settings, progress, and assessments before mounting the app
 useSettings().loadSettings()
@@ -15,6 +16,9 @@ useProgress().loadProgress()
 const { loadAssessments, loadSentHistory } = useAssessments()
 loadAssessments()
 loadSentHistory()
+
+// Initialize default PWA manifest
+useManifest().setDefaultManifest()
 
 const app = createApp(App)
 app.use(router)

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -99,4 +99,29 @@ const router = createRouter({
   }
 })
 
+// Redirect returning users from Home to their last language's workshop overview
+// In PWA (standalone) mode, always skip Home
+router.beforeEach((to) => {
+  if (to.name !== 'home') return true
+
+  const lastLang = localStorage.getItem('selectedLanguage')
+  if (!lastLang) return true // First-time visitor, show Home
+
+  const isStandalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true
+  const hasVisited = localStorage.getItem('hasVisitedBefore')
+
+  if (isStandalone || hasVisited) {
+    return { name: 'workshop-overview', params: { learning: lastLang } }
+  }
+
+  return true
+})
+
+// Track that the user has visited before
+router.afterEach((to) => {
+  if (to.name === 'workshop-overview' || to.name === 'lessons-overview') {
+    localStorage.setItem('hasVisitedBefore', 'true')
+  }
+})
+
 export default router

--- a/src/views/LessonsOverview.vue
+++ b/src/views/LessonsOverview.vue
@@ -97,13 +97,13 @@
       </div>
     </div>
 
-    <!-- Install as app button -->
+    <!-- Install single workshop as app -->
     <div v-if="!isLoading && lessons.length > 0 && !isStandalone" class="mt-3 flex justify-center">
       <button
         @click="installApp"
         class="flex items-center gap-2 px-5 py-2.5 rounded-xl border-2 border-muted-foreground/20 text-muted-foreground hover:border-primary hover:text-primary transition text-sm font-medium">
         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-        {{ isDE ? 'Als App installieren' : 'Install as App' }}
+        {{ isDE ? `„${workshopTitle}" als App` : `Install "${workshopTitle}" as App` }}
       </button>
     </div>
 
@@ -118,7 +118,7 @@
     <div v-if="showIOSInstall" class="fixed inset-0 z-50 bg-black/60 flex items-end justify-center p-4" @click.self="showIOSInstall = false">
       <div class="bg-background rounded-2xl p-6 max-w-sm w-full mb-8 shadow-xl">
         <h3 class="font-semibold text-lg text-foreground mb-3">
-          {{ isDE ? 'Als App installieren' : 'Install as App' }}
+          {{ isDE ? `„${workshopTitle}" als App` : `Install "${workshopTitle}"` }}
         </h3>
         <p class="text-muted-foreground text-sm mb-4">
           {{ isDE
@@ -147,6 +147,7 @@ import { useLessons } from '../composables/useLessons'
 import { useProgress } from '../composables/useProgress'
 import { useAssessments } from '../composables/useAssessments'
 import { useOffline } from '../composables/useOffline'
+import { useManifest } from '../composables/useManifest'
 import { formatLangName } from '../utils/formatters'
 import ProgressBar from '@/components/ProgressBar.vue'
 import LessonCard from '@/components/LessonCard.vue'
@@ -165,6 +166,7 @@ const {
 } = useProgress()
 const { getAssessments } = useAssessments()
 const { isOnline: online, isWorkshopOffline, getDownloadStatus, downloadWorkshop } = useOffline()
+const { setWorkshopManifest: applyWorkshopManifest, setDefaultManifest } = useManifest()
 
 const lessons = ref([])
 const isLoading = ref(true)
@@ -297,19 +299,7 @@ function openLesson(number) {
 }
 
 function setWorkshopManifest() {
-  const manifest = {
-    name: workshopTitle.value,
-    short_name: workshopTitle.value,
-    start_url: `/#/${learning.value}/${workshop.value}/lessons`,
-    display: 'standalone',
-    background_color: '#000000',
-    theme_color: '#000000',
-    icons: [{ src: '/favicon.svg', sizes: 'any', type: 'image/svg+xml' }]
-  }
-  const blob = new Blob([JSON.stringify(manifest)], { type: 'application/json' })
-  const url = URL.createObjectURL(blob)
-  const link = document.querySelector('link[rel="manifest"]')
-  if (link) link.href = url
+  applyWorkshopManifest(workshopTitle.value, learning.value, workshop.value)
 }
 
 async function installApp() {
@@ -368,5 +358,6 @@ onMounted(() => {
 onUnmounted(() => {
   document.removeEventListener('keydown', handleKeydown)
   window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
+  setDefaultManifest()
 })
 </script>

--- a/src/views/WorkshopOverview.vue
+++ b/src/views/WorkshopOverview.vue
@@ -148,16 +148,26 @@
         </div>
       </div>
 
+      <!-- Install full app -->
+      <div v-if="!isStandalone" class="mt-8 flex justify-center">
+        <button
+          @click="installFullApp"
+          class="flex items-center gap-2 px-5 py-2.5 rounded-xl border-2 border-muted-foreground/20 text-muted-foreground hover:border-primary hover:text-primary transition text-sm font-medium">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+          {{ isDE ? '„Open Learn" als App installieren' : 'Install "Open Learn" as App' }}
+        </button>
+      </div>
     </div>
 
   </div>
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useLessons } from '../composables/useLessons'
 import { useOffline } from '../composables/useOffline'
+import { useManifest } from '../composables/useManifest'
 import { useLanguage } from '../composables/useLanguage'
 import { formatLangName } from '../utils/formatters'
 import { Card } from '@/components/ui/card'
@@ -170,6 +180,12 @@ const route = useRoute()
 const { availableContent, isLoading, loadAvailableContent, loadWorkshopsForLanguage, removeContentSource, isRemoteWorkshop, isDefaultSource, getSourceForSlug, getWorkshopMeta, getContentSources } = useLessons()
 const { selectedLanguage, setLanguage } = useLanguage()
 const { isWorkshopOffline } = useOffline()
+const { setDefaultManifest } = useManifest()
+
+const isStandalone = computed(() =>
+  window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true
+)
+let deferredInstallPrompt = null
 
 const activeFilter = ref(null)
 const copiedWorkshop = ref(null)
@@ -448,7 +464,23 @@ function cleanupLegacySources() {
   }
 }
 
+function handleBeforeInstallPrompt(e) {
+  e.preventDefault()
+  deferredInstallPrompt = e
+}
+
+async function installFullApp() {
+  setDefaultManifest()
+  if (deferredInstallPrompt) {
+    deferredInstallPrompt.prompt()
+    await deferredInstallPrompt.userChoice
+    deferredInstallPrompt = null
+  }
+}
+
 onMounted(async () => {
+  window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
+  setDefaultManifest()
   cleanupLegacySources()
   // Show notification if redirected from add source with language mismatch
   if (route.query.added && route.query.availableIn) {
@@ -473,5 +505,9 @@ onMounted(async () => {
     console.log(`🎨 [WorkshopOverview] ${ws}: color="${meta.color}", primaryColor="${meta.primaryColor}"`)
   }
   emit('update-title', 'Workshops')
+})
+
+onUnmounted(() => {
+  window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
 })
 </script>


### PR DESCRIPTION
## Summary
- **Two distinct install modes** with clear manifest names and start URLs:
  - **"Install Open Learn as App"** on WorkshopOverview → full app, `start_url: /`, `name: "Open Learn"`
  - **"Install [Workshop] as App"** on LessonsOverview → single workshop, `start_url: /#/lang/workshop/lessons`, `name: "[Workshop Title]"`
- **useManifest composable** manages dynamic manifest link swapping (blob URLs)
- **Returning users skip Home** → redirected to last language's workshop overview
- **PWA standalone mode never shows Home** → always goes straight to workshops

https://claude.ai/code/session_01AjdrwWDXGRGeKZWn5HQmCH