### PR TITLE
perf: minimal home page — no workshop details without language (#123)

### DIFF
--- a/src/composables/useLessons.js
+++ b/src/composables/useLessons.js
@@ -172,8 +172,9 @@ export function useLessons() {
           codes[langKey] = source.code || null
         }
 
-        // Skip workshop details for languages the user hasn't selected
-        if (targetLang && langKey !== targetLang) continue
+        // Only load workshop details for the target language
+        // If no targetLang, skip all workshop details (language discovery only)
+        if (!targetLang || langKey !== targetLang) continue
 
         // Load workshops for this language from the remote source
         // Try workshops.yaml first, fallback to topics.yaml for backwards compatibility
@@ -278,8 +279,8 @@ export function useLessons() {
               content[langKey] = {}
             }
 
-            // Skip workshop details for languages the user hasn't selected
-            if (targetLang && langKey !== targetLang) continue
+            // Only load workshop details for the target language
+            if (!targetLang || langKey !== targetLang) continue
 
             // Load workshops for this language
             let workshopsData = null


### PR DESCRIPTION
## Summary

Closes #123. When no target language is known (home page, no stored preference), skip all `workshops.yaml` fetches. Only discover languages from `index.yaml` files.

### Before (home page, no stored language)

```
lessons/index.yaml
default-sources.yaml
┌ source1/index.yaml → source1/deutsch/workshops.yaml → source1/english/workshops.yaml → ...
│ source2/index.yaml → source2/deutsch/workshops.yaml → ...
└ ... (~24+ fetches total)
```

### After

```
lessons/index.yaml
default-sources.yaml
┌ source1/index.yaml ┐
│ source2/index.yaml │ parallel, language discovery only
└ ...                ┘ (~10 fetches, no workshops.yaml)
```

Workshop details load on demand when user selects a language.

### Change

Two-line logic flip in `loadContentSource` and `loadLocalWorkshops`:
```javascript
// Before: skip if targetLang set and doesn't match
if (targetLang && langKey !== targetLang) continue

// After: skip unless targetLang matches (no targetLang = skip all)
if (!targetLang || langKey !== targetLang) continue
```

### Flow

1. Home page → `loadAvailableContent(null)` → languages only
2. User picks "deutsch" → `loadWorkshopsForLanguage('deutsch')` → `loadSourcesForLanguage('deutsch')` → workshop details for deutsch only
3. Previously loaded language → `loadedSourceLangs` cache hit, no re-fetch

## Test plan

- [ ] Home page loads fast (no workshops.yaml in Network tab)
- [ ] Language picker shows all available languages
- [ ] Selecting a language loads workshops correctly
- [ ] Deep link to `/#/deutsch` loads deutsch workshops directly
- [ ] Stored language preference loads workshops on startup