### PR TITLE
fix: unit test failures + E2E timeout

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -36,7 +36,7 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,6 +62,6 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        run: npx playwright test --timeout 10000
+        run: npx playwright test
         env:
           CI: true

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -4,12 +4,13 @@ export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  retries: 0,
+  workers: process.env.CI ? 2 : undefined,
+  timeout: 10000,
+  reporter: process.env.CI ? 'list' : 'html',
   use: {
     baseURL: 'http://localhost:5173',
-    trace: 'on-first-retry',
+    trace: 'off',
   },
   projects: [
     {

--- a/tests/lessons.test.js
+++ b/tests/lessons.test.js
@@ -253,8 +253,8 @@ describe('useLessons', () => {
         return Promise.resolve({ ok: false, status: 404 })
       })
 
-      // Load everything to populate slug map
-      await lessons.loadAvailableContent()
+      // Load everything to populate slug map (pass targetLang to load workshop details)
+      await lessons.loadAvailableContent('deutsch')
 
       // Verify slug map was populated
       const resolved = lessons.resolveWorkshopKey('deutsch', 'my-topic')
@@ -339,7 +339,7 @@ describe('useLessons', () => {
         return Promise.resolve({ ok: false, status: 404 })
       })
 
-      await lessons.loadAvailableContent()
+      await lessons.loadAvailableContent('deutsch')
       fetchCalls.length = 0
 
       const lesson = await lessons.loadLesson('deutsch', 'my-topic', '01-intro')


### PR DESCRIPTION
## Summary

Fixes test failures introduced by single-language loading (#126, #127, #128).

### Unit tests
Tests that need workshop data now pass `'deutsch'` as `targetLang` to `loadAvailableContent()`. Without it, the function only discovers languages (no workshop details loaded), causing slug map to be empty.

### E2E timeout
- 2 workers instead of 1
- No retries (was 2)
- 10s per-test timeout in playwright.config.js
- 5min job timeout (3min was too tight with browser install)
- Trace off, list reporter in CI

## Test plan
- [ ] Unit tests pass
- [ ] E2E tests complete within 5min