### PR TITLE
fix: resolve image URLs for remote workshops (#140)

### DIFF
--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -350,7 +350,8 @@ function resolveLessonAssetPath(assetPath) {
   const filename = lesson.value?._filename || `${String(lesson.value?.number).padStart(2, '0')}-lesson`
   const resolvedWorkshop = resolveWorkshopKey(learning.value, workshop.value)
   if (resolvedWorkshop !== workshop.value) {
-    return `${baseUrl}${resolvedWorkshop}/${filename}/${assetPath}`
+    const prefix = resolvedWorkshop.startsWith('http://') || resolvedWorkshop.startsWith('https://') ? '' : baseUrl
+    return `${prefix}${resolvedWorkshop}/${filename}/${assetPath}`
   }
   return `${baseUrl}lessons/${learning.value}/${workshop.value}/${filename}/${assetPath}`
 }

--- a/src/views/LessonsOverview.vue
+++ b/src/views/LessonsOverview.vue
@@ -280,7 +280,8 @@ function resolveLessonImage(lesson) {
   }
   const resolvedWorkshop = resolveWorkshopKey(learning.value, workshop.value)
   if (resolvedWorkshop !== workshop.value) {
-    return `${baseUrl}${resolvedWorkshop}/${lesson._source?.path || lesson._filename}/${imagePath}`
+    const prefix = resolvedWorkshop.startsWith('http://') || resolvedWorkshop.startsWith('https://') ? '' : baseUrl
+    return `${prefix}${resolvedWorkshop}/${lesson._source?.path || lesson._filename}/${imagePath}`
   }
   return `${baseUrl}lessons/${learning.value}/${workshop.value}/${lesson._filename}/${imagePath}`
 }


### PR DESCRIPTION
## Summary
- Remote workshop images (lesson cards + lesson detail) were broken — showing alt text instead of SVGs
- **Root cause:** `baseUrl` (`/`) was prepended to already-absolute URLs from `resolveWorkshopKey()`, creating invalid paths like `/https://open-learn.app/...`
- Fix: Skip `baseUrl` prefix when `resolvedWorkshop` is already an absolute URL

**Affected files:**
- `LessonsOverview.vue` → `resolveLessonImage()`
- `LessonDetail.vue` → `resolveLessonAssetPath()`

Closes #140

## Testen
```bash
git checkout fix/lesson-images-140 && pnpm dev
```

Dann öffne:
- http://localhost:5173/#/deutsch/linux-grundlagen/lessons → Thumbnails sichtbar?
- http://localhost:5173/#/deutsch/linux-grundlagen/lesson/2 → Header-Bild sichtbar?