### PR TITLE
feat: numbered section headings + visual structure (#142)

### DIFF
--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -358,7 +358,8 @@ function resolveLessonAssetPath(assetPath) {
   const filename = lesson.value?._filename || `${String(lesson.value?.number).padStart(2, '0')}-lesson`
   const resolvedWorkshop = resolveWorkshopKey(learning.value, workshop.value)
   if (resolvedWorkshop !== workshop.value) {
-    return `${baseUrl}${resolvedWorkshop}/${filename}/${assetPath}`
+    const prefix = resolvedWorkshop.startsWith('http://') || resolvedWorkshop.startsWith('https://') ? '' : baseUrl
+    return `${prefix}${resolvedWorkshop}/${filename}/${assetPath}`
   }
   return `${baseUrl}lessons/${learning.value}/${workshop.value}/${filename}/${assetPath}`
 }

--- a/src/views/LessonsOverview.vue
+++ b/src/views/LessonsOverview.vue
@@ -280,7 +280,8 @@ function resolveLessonImage(lesson) {
   }
   const resolvedWorkshop = resolveWorkshopKey(learning.value, workshop.value)
   if (resolvedWorkshop !== workshop.value) {
-    return `${baseUrl}${resolvedWorkshop}/${lesson._source?.path || lesson._filename}/${imagePath}`
+    const prefix = resolvedWorkshop.startsWith('http://') || resolvedWorkshop.startsWith('https://') ? '' : baseUrl
+    return `${prefix}${resolvedWorkshop}/${lesson._source?.path || lesson._filename}/${imagePath}`
   }
   return `${baseUrl}lessons/${learning.value}/${workshop.value}/${lesson._filename}/${imagePath}`
 }


### PR DESCRIPTION
## Summary
- Section headings now show numbered badges (1, 2, 3...) matching the TOC navigation
- TOC uses round number badges instead of plain list-decimal
- Explanation boxes have a colored accent bar on the left
- Section cards have subtle borders and shadows for clearer visual separation

Closes #142

## Testen
```bash
git checkout feat/lesson-visual-structure-142 && pnpm dev
```

Dann öffne:
- http://localhost:5173/#/deutsch/linux-grundlagen/lesson/2 → Nummern in TOC + Sections?
- http://localhost:5173/#/deutsch/linux-grundlagen/lesson/1 → Erklärungsbox mit Akzent?