### PR TITLE
fix: Workshops laden nicht bei direktem URL-Zugriff (#145)

### DIFF
--- a/src/composables/useLessons.js
+++ b/src/composables/useLessons.js
@@ -411,6 +411,7 @@ export function useLessons() {
   async function loadSourcesForLanguage(lang) {
     if (loadedSourceLangs.has(lang)) return
     console.log(`📡 Loading source workshop details for language: ${lang}`)
+    await loadDefaultSources()
     const contentSources = getAllContentSources()
     await Promise.all(
       contentSources.map(sourceUrl =>


### PR DESCRIPTION
## Summary
- `loadSourcesForLanguage()` lud `default-sources.yaml` nicht, wenn man direkt auf `/#/deutsch` navigierte (z.B. Mobile-Bookmark)
- 1 Zeile Fix: `await loadDefaultSources()` vor `getAllContentSources()`

Closes #145

## Testen
```bash
git checkout fix/workshop-loading-direct-url-145 && pnpm dev
```

Dann öffne direkt (nicht über Home navigieren):
- http://localhost:5173/#/deutsch

Workshops müssen sichtbar sein. Auch auf dem Handy testen über die Network-URL.