### PR TITLE
fix: nav bar title truncated on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - `_filename` auf Lesson-Objekt setzen statt Fallback auf `XX-lesson`
 - Doppel-Slash bei lokalen Workshop-Pfaden (`/__local/...`) verhindern
 
+#### Nav-Titel abgeschnitten auf Mobile (#149)
+- Kleinere Schriftgröße auf kleinen Screens (text-lg statt text-xl)
+- Story-Button auf sehr kleinen Screens ausgeblendet für mehr Titelplatz
+
 ## 2026-03-27
 
 ### Features

--- a/src/App.vue
+++ b/src/App.vue
@@ -63,7 +63,7 @@
         </div>
 
         <!-- Title (grows to fill available space) -->
-        <h1 class="text-xl md:text-3xl font-bold flex-grow truncate px-3 flex items-center gap-2">
+        <h1 class="text-lg sm:text-xl md:text-3xl font-bold flex-grow truncate px-3 flex items-center gap-2">
           <span class="truncate">{{ pageTitle }}</span>
           <span v-if="!online" class="flex-shrink-0 inline-flex items-center gap-1 bg-white/20 text-white/80 text-xs font-medium px-2 py-0.5 rounded-full">
             <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="2" x2="22" y1="2" y2="22"/><path d="M8.5 16.5a5 5 0 0 1 7 0"/><path d="M2 8.82a15 15 0 0 1 4.17-2.65"/><path d="M10.66 5c4.01-.36 8.14.9 11.34 3.76"/><path d="M16.85 11.25a10 10 0 0 1 2.22 1.68"/><path d="M5 12.86a10 10 0 0 1 5.17-2.94"/></svg>
@@ -94,7 +94,7 @@
             variant="ghost"
             size="icon"
             @click="enterStoryMode"
-            class="bg-white/20 border-2 border-white/50 text-white hover:bg-white/30 hover:text-white rounded-full w-10 h-10 flex-shrink-0"
+            class="hidden sm:flex bg-white/20 border-2 border-white/50 text-white hover:bg-white/30 hover:text-white rounded-full w-10 h-10 flex-shrink-0"
             title="Story Mode"
             aria-label="Story Mode">
             <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>


### PR DESCRIPTION
## Problem
Auf dem Handy wird der Workshop-/Lektionstitel in der Navigationsleiste abgeschnitten — z.B. "Linux Grundla..." statt "Linux Grundlagen". Die vielen Buttons in der Nav-Bar lassen zu wenig Platz für den Titel.

## Ursache
Der Titel hat `text-xl` auf allen Bildschirmgrößen, und der Story-Mode-Button nimmt auf kleinen Screens unnötig Platz weg.

## Fix
2 Änderungen in `src/App.vue`:
- Schriftgröße gestuft: `text-lg` (< 640px) → `text-xl` (640px+) → `text-3xl` (Desktop)
- Story-Mode-Button wird unter 640px ausgeblendet (`hidden sm:flex`) → mehr Platz für den Titel

## Testen
```bash
git checkout fix/nav-title-mobile && pnpm dev
```
Öffne im schmalen Browser-Fenster oder Handy:
- http://localhost:5173/#/deutsch/linux-grundlagen/lessons

**Prüfen:**
- [ ] Titel "Linux Grundlagen" vollständig sichtbar auf Mobile
- [ ] Nav-Bar nicht überladen