### PR TITLE
fix: show loading state instead of 'no workshops' while loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 - Kleinere Schriftgröße auf kleinen Screens (text-lg statt text-xl)
 - Story-Button auf sehr kleinen Screens ausgeblendet für mehr Titelplatz
 
+#### Show loading state instead of "no workshops" while loading (#150)
+- Add local loading indicator in WorkshopOverview while workshops are being fetched
+- Prevents "Keine Workshops verfügbar" from flashing before content loads
+
 ## 2026-03-27
 
 ### Features

--- a/src/views/WorkshopOverview.vue
+++ b/src/views/WorkshopOverview.vue
@@ -120,6 +120,12 @@
         </Card>
       </div>
 
+      <!-- Loading workshops -->
+      <div v-else-if="workshopsLoading" class="text-center py-8">
+        <div class="inline-block w-6 h-6 border-3 border-primary/30 border-t-primary rounded-full animate-spin mb-3"></div>
+        <p class="text-muted-foreground text-sm">{{ isDE ? 'Workshops laden...' : 'Loading workshops...' }}</p>
+      </div>
+
       <!-- No workshops -->
       <p v-else class="text-muted-foreground text-center py-8">
         {{ t('noWorkshops') }}
@@ -187,6 +193,7 @@ const isStandalone = computed(() =>
 )
 let deferredInstallPrompt = null
 
+const workshopsLoading = ref(true)
 const activeFilter = ref(null)
 const copiedWorkshop = ref(null)
 const addedNotice = ref(null)
@@ -499,6 +506,7 @@ onMounted(async () => {
   if (learning.value) {
     await loadWorkshopsForLanguage(learning.value)
   }
+  workshopsLoading.value = false
   // Debug: log colors for all workshops
   for (const ws of workshops.value) {
     const meta = getWorkshopMeta(learning.value, ws)


### PR DESCRIPTION
## Problem
Beim Öffnen der Workshop-Übersicht erscheint kurz die Meldung "Keine Workshops verfügbar", obwohl die Workshops noch im Hintergrund laden. Das verwirrt Nutzer — sie denken es gibt keine Inhalte.

## Ursache
Der bestehende `isLoading`-State deckt nur `loadAvailableContent()` ab, aber nicht `loadWorkshopsForLanguage()`. Zwischen diesen beiden Aufrufen ist `filteredWorkshops` leer → die "Keine Workshops"-Meldung erscheint.

## Fix
In `src/views/WorkshopOverview.vue`:
- Neuer `workshopsLoading` Ref der den gesamten Ladevorgang abdeckt (beide async Funktionen)
- Spinner mit "Workshops laden..." wird angezeigt solange geladen wird
- "Keine Workshops verfügbar" erscheint erst wenn wirklich nichts da ist

## Testen
```bash
git checkout fix/workshop-loading-state && pnpm dev
```
Öffne:
- http://localhost:5173/#/deutsch

**Prüfen:**
- [ ] Spinner erscheint beim Laden (nicht "Keine Workshops")
- [ ] Nach dem Laden: alle Workshops sichtbar
- [ ] Kein kurzes Aufblitzen von "Keine Workshops verfügbar"