### PR TITLE
fix: Lesson-Bilder laden nicht in LessonDetail (falscher Pfad)

### DIFF
--- a/src/composables/useLessons.js
+++ b/src/composables/useLessons.js
@@ -542,6 +542,7 @@ export function useLessons() {
         console.log(`  ✓ Lesson loaded: #${lesson.number} - ${lesson.title}`)
         // Store the source path for audio loading
         lesson._source = source
+        lesson._filename = source.path
       } else {
         console.error(`  ❌ Failed to parse lesson: ${filenameOrSource}`)
       }

--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -358,7 +358,7 @@ function resolveLessonAssetPath(assetPath) {
   const filename = lesson.value?._filename || `${String(lesson.value?.number).padStart(2, '0')}-lesson`
   const resolvedWorkshop = resolveWorkshopKey(learning.value, workshop.value)
   if (resolvedWorkshop !== workshop.value) {
-    const prefix = resolvedWorkshop.startsWith('http://') || resolvedWorkshop.startsWith('https://') ? '' : baseUrl
+    const prefix = resolvedWorkshop.startsWith('http://') || resolvedWorkshop.startsWith('https://') || resolvedWorkshop.startsWith('/') ? '' : baseUrl
     return `${prefix}${resolvedWorkshop}/${filename}/${assetPath}`
   }
   return `${baseUrl}lessons/${learning.value}/${workshop.value}/${filename}/${assetPath}`


### PR DESCRIPTION
## Summary
- `lesson._filename` wird jetzt in `loadLesson()` gesetzt
- `resolveLessonAssetPath` prüft jetzt auch auf Pfade die mit `/` starten

## Testen
```bash
git checkout fix/lesson-image-paths && pnpm dev
```
- http://localhost:5179/#/deutsch/local-dev:linux-grundlagen/lesson/1

Section-Bilder und Lesson-Header müssen sichtbar sein.