### PR TITLE
fix: E2E guide link selector + test docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,15 +108,24 @@ pnpm build
 # Preview production build locally
 pnpm preview
 
-# Run unit tests (Vitest)
+# Run unit tests (Vitest) — single run, exits when done
+npx vitest --run
+
+# Run unit tests in watch mode
 pnpm test
 
 # Run unit tests with UI
 pnpm test:ui
 
-# Run E2E tests (Playwright)
+# Run E2E tests (Playwright) — needs `pnpm build` first or dev server running
 pnpm test:e2e
+
+# Run E2E smoke tests only (used in CI)
+pnpm test:e2e:smoke
 ```
+
+> **Note:** `pnpm test` starts Vitest in watch mode (hangs). Use `npx vitest --run` for a single run that exits.
+> E2E tests start their own preview server automatically. Full suite takes ~45s locally.
 
 ### Local Workshop Development
 

--- a/tests/e2e/home.spec.js
+++ b/tests/e2e/home.spec.js
@@ -84,8 +84,8 @@ test.describe('Workshop Overview', () => {
     await page.waitForTimeout(2000);
 
     // Should show footer links
-    await expect(page.getByRole('link', { name: 'Guide' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Feedback' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Guide', exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Feedback', exact: true })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Bug Report' })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Fix failing E2E test `home.spec.js:87` — `getByRole('link', { name: 'Guide' })` matched 2 elements (workshop source link + footer link). Added `{ exact: true }`.
- Document test commands in CLAUDE.md: `npx vitest --run` for single run (avoids watch mode hang), E2E smoke command, timing notes.

## Test results (local)

| Suite | Result | Duration |
|-------|--------|----------|
| Unit tests | 139 passed | 4.25s |
| E2E tests | 55 passed | ~45s |