### PR TITLE
feat: 404 page for unknown routes

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page Not Found – Open Learn</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 480px; margin: 80px auto; padding: 0 20px; color: #1e293b; text-align: center; }
+    h1 { font-size: 3rem; margin-bottom: 0.25rem; color: #94a3b8; }
+    h2 { font-size: 1.25rem; margin-bottom: 1.5rem; }
+    p { color: #64748b; line-height: 1.7; margin-bottom: 2rem; }
+    .links { display: flex; flex-direction: column; gap: 0.75rem; align-items: center; }
+    .links a { display: inline-block; padding: 10px 28px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 0.95rem; }
+    .primary { background: #2563eb; color: white; }
+    .primary:hover { background: #1d4ed8; }
+    .secondary { color: #2563eb; border: 1px solid #bfdbfe; }
+    .secondary:hover { background: #eff6ff; }
+    footer { margin-top: 3rem; font-size: 0.8rem; color: #94a3b8; }
+    footer a { color: #64748b; }
+  </style>
+</head>
+<body>
+  <h1>404</h1>
+  <h2>Page not found</h2>
+  <p>The page you're looking for doesn't exist or may have moved.</p>
+  <div class="links">
+    <a class="primary" href="https://open-learn.app">Go to Open Learn</a>
+    <a class="secondary" href="https://github.com/openlearnapp">Browse Workshops on GitHub</a>
+  </div>
+  <footer>
+    <a href="https://open-learn.app">open-learn.app</a>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Add a `404.html` page to `public/`. GitHub Pages serves this for any path that doesn't match an actual file.

Previously, unknown paths (like `/some-random-path`) served the SPA's `index.html`, which showed the home page — confusing for users who expected a specific page.

Now shows a clean "Page not found" with links to:
- Open Learn home page
- GitHub org (browse workshops)

## Test plan

- [ ] Visit `https://open-learn.app/nonexistent-path` → shows 404 page
- [ ] Workshop landing pages still work (they have their own index.html)
- [ ] Hash routes (`/#/deutsch`) still work (SPA handles them)