### PR TITLE
fix: Service Worker intercepting workshop landing pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -85,6 +85,8 @@ export default defineConfig(({ command }) => ({
       workbox: {
         // Precache built app assets
         globPatterns: ['**/*.{js,css,html,svg,png,woff2}'],
+        // Don't intercept navigation to workshop landing pages or 404
+        navigateFallbackDenylist: [/^\/workshop-/, /^\/404\.html/],
         // Runtime caching for workshop metadata (always cached, stale-while-revalidate)
         runtimeCaching: [
           {


### PR DESCRIPTION
## Problem

Normal reload on `open-learn.app/workshop-k0rdent/` shows the Open Learn home page instead of the workshop landing page. Hard reload (Cmd+Shift+R) works correctly.

**Cause:** The Service Worker (vite-plugin-pwa/Workbox) precaches `index.html` and uses it as `navigateFallback` for all navigation requests — including `/workshop-*` paths that should serve the workshop's own `index.html`.

## Fix

Add `navigateFallbackDenylist` to exclude `/workshop-*` and `/404.html` paths from the SW navigation fallback:

```javascript
navigateFallbackDenylist: [/^\/workshop-/, /^\/404\.html/],
```

The SW still caches and serves the SPA for hash-based routes (`/#/deutsch`), but lets the browser fetch workshop landing pages directly from the server.

## Test plan

- [ ] Normal reload on `/workshop-k0rdent/` shows workshop landing page
- [ ] Hard reload also works
- [ ] Hash routes (`/#/deutsch`) still work via SW
- [ ] 404 page shows for unknown paths
- [ ] Existing users need to wait for SW update (autoUpdate)