### PR TITLE
feat: add source respects lang from workshop landing page

### DIFF
--- a/src/views/AddSource.vue
+++ b/src/views/AddSource.vue
@@ -54,9 +54,10 @@ import { Card, CardContent } from '@/components/ui/card'
 const router = useRouter()
 const route = useRoute()
 const { getContentSources, addContentSource, loadAvailableContent } = useLessons()
-const { selectedLanguage } = useLanguage()
+const { selectedLanguage, setLanguage } = useLanguage()
 
 const sourceUrl = ref(route.query.source || '')
+const requestedLang = ref(route.query.lang || '')
 const isValidating = ref(false)
 const error = ref(null)
 
@@ -137,14 +138,22 @@ async function validateAndAddSource() {
     }
 
     // Reload content so the new source is available for navigation
-    await loadAvailableContent()
+    const targetLangForLoad = requestedLang.value || selectedLanguage.value || Object.keys(content)[0]
+    await loadAvailableContent(targetLangForLoad)
 
-    // Determine where to navigate
-    const userLang = selectedLanguage.value || 'deutsch'
+    // Determine target language: requested from landing page > user's selected > fallback
+    const targetLang = (requestedLang.value && content[requestedLang.value])
+      ? requestedLang.value
+      : (content[selectedLanguage.value] ? selectedLanguage.value : null)
+    const userLang = targetLang || Object.keys(content)[0] || 'deutsch'
+
+    // Switch platform language to match
+    setLanguage(userLang)
+
     const workshopsForLang = content[userLang]
 
     if (workshopsForLang && workshopsForLang.length === 1) {
-      // Single workshop available in user's language — go directly to lessons
+      // Single workshop available — go directly to lessons
       router.replace({
         name: 'lessons-overview',
         params: { learning: userLang, workshop: workshopsForLang[0] }
@@ -156,7 +165,7 @@ async function validateAndAddSource() {
         params: { learning: userLang }
       })
     } else {
-      // Workshop not available in user's language — go to workshop overview with notification
+      // Workshop not available — go to workshop overview with notification
       const availableLangs = Object.keys(content).map(l => formatLangName(l)).join(', ')
       const workshopNames = Object.values(content).flat().map(w => formatLangName(w)).join(', ')
       router.replace({


### PR DESCRIPTION
## Summary

When clicking "Add Workshop to Open Learn" from a workshop landing page, the platform now:

1. Reads `?lang=english` from the URL
2. Switches the platform language to match
3. Navigates directly to the workshop's lessons in that language

### URL format

```
https://open-learn.app/#/add?source=https://open-learn.app/workshop-k0rdent/index.yaml&lang=english
```

### Changes in AddSource.vue

- Read `lang` query parameter
- Use it as preferred language (over user's current selection)
- Call `setLanguage()` to switch platform language
- Pass `targetLang` to `loadAvailableContent()` for faster loading

### Workshop landing page (separate repo)

The k0rdent landing page now passes `&lang=` based on the selected language in its dropdown.

## Test plan

- [ ] Click "Add Workshop" from landing page with English selected → platform shows English workshop lessons
- [ ] Without `lang` param → falls back to user's current language
- [ ] Workshop not available in requested language → shows notification