### PR TITLE
fix: open-learn.js store reactive unwrapping

### DIFF
--- a/public/shared/open-learn.js
+++ b/public/shared/open-learn.js
@@ -129,12 +129,12 @@ window.OpenLearn = {
       loaded.value = true
     }
 
-    return {
+    return reactive({
       loaded, selectedLang, languages, langData,
       workshop: ws, title, description, labels, lessons,
       addUrl, ghUrl, workshopName, sourceUrl,
       selectLanguage, init
-    }
+    })
   }
 
   // ============================================================


### PR DESCRIPTION
store refs not unwrapping in component templates — wrap in reactive()