### PR TITLE
fix: audio URL double prefix for external workshops

### DIFF
--- a/src/composables/useAudio.js
+++ b/src/composables/useAudio.js
@@ -30,7 +30,9 @@ function getAudioBase(lesson, learning, workshop) {
   if (lesson._source && lesson._source.type === 'url') {
     return `${lesson._source.path}/audio`
   } else if (resolvedWorkshop && resolvedWorkshop !== workshop) {
-    return `${baseUrl}${resolvedWorkshop}/${lessonFilename}/audio`
+    // resolvedWorkshop may be an absolute URL (external) or relative path (built-in)
+    const prefix = resolvedWorkshop.startsWith('http') ? '' : baseUrl
+    return `${prefix}${resolvedWorkshop}/${lessonFilename}/audio`
   } else if (learning && (learning.startsWith('http://') || learning.startsWith('https://'))) {
     return `${learning}/${workshop}/${lessonFilename}/audio`
   } else {


### PR DESCRIPTION
## Problem

Audio URLs for external workshops got a double prefix:
```
https://open-learn.app/https://open-learn.app/workshop-milas-abenteuer/.../audio/0-0-q.mp3
```

`getAudioBase()` prepended `baseUrl` (`/`) to `resolvedWorkshop` which is already an absolute URL for external workshops.

## Fix

Check if `resolvedWorkshop` starts with `http` — if so, skip `baseUrl` prefix.

## Test plan

- [ ] Mila story mode plays audio from external repo
- [ ] Built-in workshop audio still works (relative paths)