### PR TITLE
fix: resolve lesson image paths for local workshops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 Tippen links oder rechts (egal wo auf dem Bildschirm) springt jetzt zum nächsten bzw. vorherigen Absatz innerhalb der aktuellen Section — ohne die Section zu wechseln. Audio spielt sofort den neuen Absatz ab. Die Section wechselt erst automatisch nach dem letzten Absatz.
 
+#### Lektion-Bilder auf Lernpfadseite nicht sichtbar (lokal)
+- `resolveLessonImage` berücksichtigt jetzt auch Pfade mit `/`-Präfix (lokale Workshops via `/__local/...`)
+- Verhindert doppelten Slash (`//`) bei URL-Konstruktion für lokale Workshop-Bilder
+
 ## 2026-04-12
 
 ### Fixes

--- a/src/views/LessonsOverview.vue
+++ b/src/views/LessonsOverview.vue
@@ -280,7 +280,7 @@ function resolveLessonImage(lesson) {
   }
   const resolvedWorkshop = resolveWorkshopKey(learning.value, workshop.value)
   if (resolvedWorkshop !== workshop.value) {
-    const prefix = resolvedWorkshop.startsWith('http://') || resolvedWorkshop.startsWith('https://') ? '' : baseUrl
+    const prefix = (resolvedWorkshop.startsWith('http://') || resolvedWorkshop.startsWith('https://') || resolvedWorkshop.startsWith('/')) ? '' : baseUrl
     return `${prefix}${resolvedWorkshop}/${lesson._source?.path || lesson._filename}/${imagePath}`
   }
   return `${baseUrl}lessons/${learning.value}/${workshop.value}/${lesson._filename}/${imagePath}`


### PR DESCRIPTION
## Problem

Lesson header images on the lessons overview were broken for local workshops (`/__local/...`). The `resolveLessonImage` function prepended `baseUrl` (`/`) to paths already starting with `/`, resulting in `//workshop-name/...` — an invalid URL.

## Fix

Add `|| resolvedWorkshop.startsWith('/')` to the prefix check so absolute paths are never prepended with `baseUrl`.

## Test

1. `pnpm dev` with a local workshop sibling directory
2. Navigate to lessons overview of a local workshop
3. Lesson header images should load correctly