### PR TITLE
fix: local-dev deep-link loads no lessons (local-dev: slug not registered)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,12 @@ Full suite: **17 files, 234 tests, all passing.** Build clean.
 
 ## 2026-04-03
 
+### Fixes
+
+#### Lektion-Bilder auf Lernpfadseite nicht sichtbar (lokal)
+- `resolveLessonImage` berücksichtigt jetzt auch Pfade mit `/`-Präfix (lokale Workshops via `/__local/...`)
+- Verhindert doppelten Slash (`//`) bei URL-Konstruktion für lokale Workshop-Bilder
+
 ### Features
 
 #### Burger Menu für Navigation (#130)

--- a/src/composables/useLessons.js
+++ b/src/composables/useLessons.js
@@ -473,11 +473,14 @@ export function useLessons() {
             matching.map(url => loadContentSource(url, availableContent.value, languageCodes.value, lang))
           )
         } else {
-          // Workshop not found in sources — might be built-in, load all
-    
+          // Workshop not found in sources — might be built-in or local-dev, load all
+
           await Promise.all(
             contentSources.map(url => loadContentSource(url, availableContent.value, languageCodes.value, lang))
           )
+          if (import.meta.env.DEV) {
+            await loadLocalWorkshops(availableContent.value, languageCodes.value, lang)
+          }
           loadedSourceLangs.add(lang)
         }
       } else if (!loadedSourceLangs.has(lang)) {


### PR DESCRIPTION
## Bug

Wenn man direkt zu `#/lang/local-dev:workshop/lessons` navigiert (Deep-Link), wurden keine Lektionen geladen — obwohl alle lokalen Dateien korrekt vorhanden waren.

## Ursache

In `loadSourcesForLanguage` gibt es zwei Code-Pfade:

1. **Workshop-Übersicht** (`workshopHint = undefined`): Lädt alle Remote-Sources **und** ruft `loadLocalWorkshops` auf ✅
2. **Deep-Link** (`workshopHint = 'local-dev:k0rdent-workshop'`): Prüft ob die URL in ContentSources enthalten ist → nicht gefunden → lädt alle Remote-Sources, aber vergisst `loadLocalWorkshops` ❌

## Fix

`loadLocalWorkshops` auch im `else`-Zweig aufrufen (1 Zeile).

## Test

```
# pnpm dev starten, dann direkt:
http://localhost:5174/#/english/local-dev:k0rdent-workshop/lessons
http://localhost:5174/#/farsi/local-dev:k0rdent-workshop/lessons
http://localhost:5174/#/arabic/local-dev:k0rdent-workshop/lessons
```

Vorher: "Keine Lektionen gefunden"  
Nachher: Lektionen laden ✓