### PR TITLE
feat: progress sync with unlearn support (timestamps)

### DIFF
--- a/src/composables/useGun.js
+++ b/src/composables/useGun.js
@@ -446,13 +446,22 @@ async function autoSyncAll() {
           }
           localStorage.setItem(key, JSON.stringify(local))
         } else {
-          // Progress, assessments: additive merge at nested key level
+          // Progress, assessments: timestamp-aware merge at item level.
+          // Highest absolute value wins (supports legacy true values).
           const merged = localData ? { ...localData } : {}
           for (const [k, v] of Object.entries(remoteData)) {
             if (!merged[k]) {
               merged[k] = v
             } else if (typeof v === 'object' && v !== null) {
-              merged[k] = { ...v, ...merged[k] }
+              if (!merged[k] || typeof merged[k] !== 'object') merged[k] = {}
+              for (const [itemId, remoteVal] of Object.entries(v)) {
+                const rTs = remoteVal === true ? 1 : (typeof remoteVal === 'number' ? remoteVal : 0)
+                const localVal = merged[k][itemId]
+                const lTs = localVal === true ? 1 : (typeof localVal === 'number' ? localVal : 0)
+                if (Math.abs(rTs) > Math.abs(lTs)) {
+                  merged[k][itemId] = rTs
+                }
+              }
             }
           }
           localStorage.setItem(key, JSON.stringify(merged))

--- a/src/composables/useProgress.js
+++ b/src/composables/useProgress.js
@@ -2,7 +2,9 @@ import { ref, watch } from 'vue'
 import { useGun } from './useGun'
 
 // Shared progress state (singleton pattern)
-// Structure: { "learning:workshop": { "itemId": true, ... } }
+// Structure: { "learning:workshop": { "itemId": timestamp, ... } }
+// Positive timestamp = learned, negative = unlearned. Merge: highest absolute wins.
+// Legacy format (itemId: true) is supported for reads and migrated on write.
 const progress = ref({})
 
 // Last visited lesson per workshop: { "learning:workshop": "lesson-number" }
@@ -73,10 +75,11 @@ function getLastVisited(learning, workshop) {
   return lastVisited.value[getWorkshopKey(learning, workshop)] || null
 }
 
-// Check if an item is learned
+// Check if an item is learned (positive timestamp or legacy true)
 function isItemLearned(learning, workshop, itemId) {
   const workshopKey = getWorkshopKey(learning, workshop)
-  return progress.value[workshopKey]?.[itemId] === true
+  const val = progress.value[workshopKey]?.[itemId]
+  return val === true || (typeof val === 'number' && val > 0)
 }
 
 // Toggle learned status for an item
@@ -87,10 +90,10 @@ function toggleItemLearned(learning, workshop, itemId) {
     progress.value[workshopKey] = {}
   }
 
-  if (progress.value[workshopKey][itemId]) {
-    delete progress.value[workshopKey][itemId]
+  if (isItemLearned(learning, workshop, itemId)) {
+    progress.value[workshopKey][itemId] = -Date.now()
   } else {
-    progress.value[workshopKey][itemId] = true
+    progress.value[workshopKey][itemId] = Date.now()
   }
 
   saveProgress()
@@ -241,13 +244,21 @@ function getProgress() {
   return progress.value
 }
 
-// Merge imported progress into existing (additive)
+// Merge imported progress — timestamp-aware, highest absolute value wins.
+// Supports legacy format (true) by treating it as a low positive timestamp.
 function mergeProgress(imported) {
   for (const [workshopKey, items] of Object.entries(imported)) {
     if (!progress.value[workshopKey]) {
       progress.value[workshopKey] = {}
     }
-    Object.assign(progress.value[workshopKey], items)
+    for (const [itemId, val] of Object.entries(items)) {
+      const remoteTs = val === true ? 1 : (typeof val === 'number' ? val : 0)
+      const localVal = progress.value[workshopKey][itemId]
+      const localTs = localVal === true ? 1 : (typeof localVal === 'number' ? localVal : 0)
+      if (Math.abs(remoteTs) > Math.abs(localTs)) {
+        progress.value[workshopKey][itemId] = remoteTs
+      }
+    }
   }
   // Persist immediately — the watcher also saves, but callers may read
   // localStorage synchronously after merge (e.g. import flow, tests).

--- a/src/utils/profile.js
+++ b/src/utils/profile.js
@@ -36,7 +36,7 @@ export function computeStreak(today) {
 export function calcTotalLearned(progressObj) {
   let count = 0
   for (const items of Object.values(progressObj)) {
-    count += Object.values(items).filter(v => v === true).length
+    count += Object.values(items).filter(v => v === true || (typeof v === 'number' && v > 0)).length
   }
   return count
 }

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -307,7 +307,7 @@ const activeWorkshops = computed(() => {
     if (seen.has(key)) continue
     seen.add(key)
     const [learning, workshop] = key.split(':')
-    const learnedCount = Object.values(items).filter(v => v === true).length
+    const learnedCount = Object.values(items).filter(v => v === true || (typeof v === 'number' && v > 0)).length
     result.push({
       key, learning, workshop,
       displayName: formatLangName(workshop),

--- a/tests/progress.test.js
+++ b/tests/progress.test.js
@@ -40,13 +40,13 @@ describe('useProgress', () => {
     it('persists to localStorage', () => {
       progress.toggleItemLearned('de', 'pt', 'sei')
       const stored = JSON.parse(localStorage.getItem('progress'))
-      expect(stored['de:pt']['sei']).toBe(true)
+      expect(stored['de:pt']['sei']).toBeGreaterThan(0)
     })
 
     it('creates workshop key if missing', () => {
       progress.toggleItemLearned('en', 'de', 'hello')
       expect(progress.progress.value['en:de']).toBeDefined()
-      expect(progress.progress.value['en:de']['hello']).toBe(true)
+      expect(progress.progress.value['en:de']['hello']).toBeGreaterThan(0)
     })
 
     it('handles multiple items in same workshop', () => {
@@ -127,7 +127,7 @@ describe('useProgress', () => {
     it('returns raw progress object', () => {
       progress.toggleItemLearned('de', 'pt', 'sei')
       const raw = progress.getProgress()
-      expect(raw['de:pt']['sei']).toBe(true)
+      expect(raw['de:pt']['sei']).toBeGreaterThan(0)
     })
   })
 
@@ -154,7 +154,8 @@ describe('useProgress', () => {
     it('persists merged progress to localStorage', () => {
       progress.mergeProgress({ 'de:pt': { 'sei': true } })
       const stored = JSON.parse(localStorage.getItem('progress'))
-      expect(stored['de:pt']['sei']).toBe(true)
+      // Legacy true is treated as timestamp 1 during merge
+      expect(stored['de:pt']['sei']).toBeGreaterThan(0)
     })
   })
 })


### PR DESCRIPTION
## Summary
Change progress from boolean to timestamps so unlearn operations sync across devices.

- \`{ itemId: 1712345 }\` = learned at timestamp
- \`{ itemId: -1712346 }\` = unlearned at timestamp
- Merge: highest absolute timestamp wins
- Legacy \`true\` values supported for reads, treated as timestamp 1 during merge
- Updated: isItemLearned, toggleItemLearned, mergeProgress, Profile counts, autoSyncAll merge

## Test plan
- [ ] Learn an item on device A → appears as learned on device B
- [ ] Unlearn an item on device A → disappears on device B after sync
- [ ] Legacy progress data (true values) still works correctly
- [ ] \`npx vitest --run\` — 160 tests pass