### PR TITLE
fix: audio chain stability + focus mode for playing

### DIFF
--- a/src/composables/useAudio.js
+++ b/src/composables/useAudio.js
@@ -81,6 +81,13 @@ function buildReadingQueue(lesson, learning, workshop, settings) {
   lesson.sections.forEach((section, sectionIdx) => {
     // Filter examples based on active label and hideLearnedExamples setting
     const visibleExamples = section.examples.filter((example) => {
+      // Playing mode is for listening & repeating — skip assessment items
+      // (input / multiple-choice / select) entirely. The user can come back
+      // to the lesson in read mode to answer them.
+      if (example.type && example.type !== 'qa') {
+        return false
+      }
+
       // Filter by active label
       if (settings.activeLabel) {
         if (!example.labels || !example.labels.includes(settings.activeLabel)) {
@@ -229,6 +236,12 @@ function setupMediaSession(title, learning, workshop, settingsRef) {
 // transitions and Media Session handlers always have fresh settings.
 const latestAudioSettingsRef = ref({ readAnswers: true, audioSpeed: 1.0 })
 
+// Single-flight lock for initializeAudio. Prevents concurrent calls from
+// clobbering each other's state. If a second call arrives while the first
+// is still in-flight, it waits for the first to finish and then decides
+// whether it still needs to run.
+let _initInFlight = null
+
 // Initialize audio queue for a lesson.
 // Idempotent by default: if the composable is already playing this exact lesson
 // (e.g. during a continuous-mode transition), it returns immediately. Pass
@@ -239,69 +252,89 @@ const latestAudioSettingsRef = ref({ readAnswers: true, audioSpeed: 1.0 })
 // playing `<audio>` element (via audio.pause() + audio.src=''), which silently
 // breaks the `onended` → `playNextItem` chain. So even a force-rebuild is
 // skipped while the same lesson is actively playing — the new settings take
-// effect the next time the user pauses and resumes. This fixes the bug where a
-// GunDB sync tick, a remote settings update, or an item being marked learned
-// during playback caused the audio chain to stop after the currently playing
-// clip.
+// effect the next time the user pauses and resumes.
 async function initializeAudio(lesson, learning, workshop, settings, { force = false } = {}) {
-  latestAudioSettingsRef.value = settings
-
-  const meta = lessonMetadata.value
-  const isSameLesson =
-    meta.learning === learning &&
-    meta.workshop === workshop &&
-    meta.number === lesson.number
-
-  // During a continuous-mode transition, the composable has already loaded
-  // the new lesson in-place. Skip re-initialization so we don't destroy
-  // the active audio element and iOS media session.
-  if (isSameLesson && hasAudio.value && !isLoadingAudio.value && !force) {
-    return
+  // Serialize concurrent calls. If another init is already in-flight, wait
+  // for it, then re-evaluate whether we still need to run.
+  if (_initInFlight) {
+    try { await _initInFlight } catch {}
   }
 
-  // Defensive: never tear down the queue of an actively playing lesson.
-  // The caller can re-trigger a rebuild after the user pauses.
-  if (isSameLesson && force && (isPlaying.value || isPaused.value)) {
-    console.log(`🎧 Skipping force rebuild of "${lesson.title}" — playback is active`)
-    return
-  }
+  _initInFlight = (async () => {
+    latestAudioSettingsRef.value = settings
 
-  lessonTitle.value = lesson.title
-  lessonMetadata.value = { learning, workshop, number: lesson.number }
+    const meta = lessonMetadata.value
+    const isSameLesson =
+      meta.learning === learning &&
+      meta.workshop === workshop &&
+      meta.number === lesson.number
 
-  playbackFinished.value = false
-  isLoadingAudio.value = true
-  readingQueue.value = buildReadingQueue(lesson, learning, workshop, settings)
+    // During a continuous-mode transition, the composable has already loaded
+    // the new lesson in-place. Skip re-initialization so we don't destroy
+    // the active audio element and iOS media session.
+    if (isSameLesson && hasAudio.value && !isLoadingAudio.value && !force) {
+      return
+    }
 
-  // Fetch manifest to know which audio files exist (if missing, load all)
-  const audioBase = getAudioBase(lesson, learning, workshop)
-  const manifest = await fetchAudioManifest(audioBase)
+    // Defensive: never tear down the queue of an actively playing lesson.
+    // The caller can re-trigger a rebuild after the user pauses.
+    if (isSameLesson && force && (isPlaying.value || isPaused.value)) {
+      console.log(`🎧 Skipping force rebuild of "${lesson.title}" — playback is active`)
+      return
+    }
 
-  // Release old audio elements (if any) before creating new ones
-  releaseAudioElements(audioElements.value)
+    lessonTitle.value = lesson.title
+    lessonMetadata.value = { learning, workshop, number: lesson.number }
 
-  // Pre-load audio files (filtered by manifest if available) — fire-and-forget
-  audioElements.value = preloadAudioFiles(readingQueue.value, manifest)
+    playbackFinished.value = false
+    isLoadingAudio.value = true
+    readingQueue.value = buildReadingQueue(lesson, learning, workshop, settings)
 
-  hasAudio.value = Object.keys(audioElements.value).length > 0
-  console.log(`🔊 Audio: ${Object.keys(audioElements.value).length} files ready for "${lesson.title}"`)
+    // Fetch manifest to know which audio files exist (if missing, load all)
+    const audioBase = getAudioBase(lesson, learning, workshop)
+    const manifest = await fetchAudioManifest(audioBase)
 
-  isLoadingAudio.value = false
-  currentItemIndex.value = -1
-  isPlaying.value = false
-  isPaused.value = false
-  currentAudio.value = null
+    // Post-await guard: if playback started during our await (e.g. the caller
+    // fired play() as soon as we yielded), do NOT clobber the running state.
+    // The queue will be rebuilt on the next pause/resume or explicit call.
+    if (isPlaying.value || isPaused.value) {
+      console.log(`🎧 Playback started during init — aborting rebuild of "${lesson.title}"`)
+      isLoadingAudio.value = false
+      return
+    }
 
-  // Drop any preloaded next-lesson from a previous workshop/session
-  preloadedNextLesson.value = null
+    // Release old audio elements (if any) before creating new ones
+    releaseAudioElements(audioElements.value)
 
-  // Setup Media Session API
-  setupMediaSession(lesson.title, learning, workshop, latestAudioSettingsRef)
+    // Pre-load audio files (filtered by manifest if available) — fire-and-forget
+    audioElements.value = preloadAudioFiles(readingQueue.value, manifest)
 
-  // If continuous mode is on, start preloading the next lesson's audio now
-  // so the transition at the end is instant.
-  if (continuousMode.value && nextLessonProvider.value) {
-    setTimeout(() => preloadNextLesson(), 0)
+    hasAudio.value = Object.keys(audioElements.value).length > 0
+    console.log(`🔊 Audio: ${Object.keys(audioElements.value).length} files ready for "${lesson.title}"`)
+
+    isLoadingAudio.value = false
+    currentItemIndex.value = -1
+    isPlaying.value = false
+    isPaused.value = false
+    currentAudio.value = null
+
+    // Drop any preloaded next-lesson from a previous workshop/session
+    preloadedNextLesson.value = null
+
+    // Setup Media Session API
+    setupMediaSession(lesson.title, learning, workshop, latestAudioSettingsRef)
+
+    // If continuous mode is on, start preloading the next lesson's audio now
+    // so the transition at the end is instant.
+    if (continuousMode.value && nextLessonProvider.value) {
+      setTimeout(() => preloadNextLesson(), 0)
+    }
+  })()
+
+  try {
+    await _initInFlight
+  } finally {
+    _initInFlight = null
   }
 }
 
@@ -319,9 +352,13 @@ function releaseAudioElements(map, except = null) {
 
 // Attach the standard onended / onerror handlers to an audio element.
 // Extracted so playNextItem and playCurrentItem can share the same logic.
-function attachPlaybackHandlers(audio, item, settings) {
+// Reads settings freshly from `latestAudioSettingsRef` on every callback
+// invocation so mid-playback setting changes take effect on the next clip.
+function attachPlaybackHandlers(audio, item) {
   audio.onended = () => {
     if (!isPlaying.value) return
+    const currentSettings = latestAudioSettingsRef.value || { readAnswers: true, audioSpeed: 1.0 }
+
     // Determine pause duration based on item type
     let pauseDuration = 0
 
@@ -331,7 +368,7 @@ function attachPlaybackHandlers(audio, item, settings) {
       pauseDuration = 1000
     } else {
       const isEndOfExample = item.type === 'answer' ||
-        (item.type === 'question' && !settings.readAnswers)
+        (item.type === 'question' && !currentSettings.readAnswers)
 
       if (isEndOfExample) {
         const nextItem = readingQueue.value[currentItemIndex.value + 1]
@@ -342,16 +379,16 @@ function attachPlaybackHandlers(audio, item, settings) {
 
     if (pauseDuration > 0) {
       setTimeout(() => {
-        if (isPlaying.value) playNextItem(settings)
+        if (isPlaying.value) playNextItem(latestAudioSettingsRef.value || currentSettings)
       }, pauseDuration)
     } else {
-      playNextItem(settings)
+      playNextItem(latestAudioSettingsRef.value || currentSettings)
     }
   }
 
-  audio.onerror = (e) => {
+  audio.onerror = () => {
     console.warn('⚠️ Audio error, retrying:', item.audioUrl)
-    retryPlay(item, settings)
+    retryPlay(item, latestAudioSettingsRef.value || { readAnswers: true, audioSpeed: 1.0 })
   }
 }
 
@@ -410,7 +447,7 @@ async function playNextItem(settings) {
       audio.playbackRate = settings.audioSpeed || 1.0
     }
 
-    attachPlaybackHandlers(audio, item, settings)
+    attachPlaybackHandlers(audio, item)
 
     // Play
     await audio.play()
@@ -483,7 +520,7 @@ async function playCurrentItem(settings) {
       audio.playbackRate = settings.audioSpeed || 1.0
     }
 
-    attachPlaybackHandlers(audio, item, settings)
+    attachPlaybackHandlers(audio, item)
 
     // Play from current position (resume)
     await audio.play()
@@ -502,9 +539,12 @@ function play(settings) {
 
   latestAudioSettingsRef.value = settings
 
-  // Guard: if already playing, don't restart (avoids lock-screen "play" handler
-  // from re-starting in the middle of an item).
-  if (isPlaying.value && currentAudio.value && !currentAudio.value.paused) {
+  // Guard: if the chain is already running (isPlaying=true and not paused),
+  // don't re-enter. We check isPlaying+isPaused instead of currentAudio.paused
+  // because the native `audio.paused` flag flips to true between clips (after
+  // onended fires), and that false-negative used to let re-entrant play()
+  // calls double-advance the queue.
+  if (isPlaying.value && !isPaused.value) {
     return
   }
 
@@ -788,6 +828,14 @@ const currentItem = computed(() => {
   return null
 })
 
+// Focus mode: true whenever the audio chain is actively playing (not paused,
+// not stopped). The UI uses this to disable all state-mutating interactions
+// while a lesson is being played — learn toggles, assessment inputs, settings
+// switches, label clicks, etc. This collapses the test matrix: instead of
+// guarding every individual mutation path against "is the audio chain
+// running?", the view layer hides or disables those controls entirely.
+const isInFocusMode = computed(() => isPlaying.value && !isPaused.value)
+
 // Cleanup
 function cleanup() {
   // During a continuous-mode transition, skip teardown so the new lesson can
@@ -819,6 +867,7 @@ export function useAudio() {
     isLoadingAudio,
     isPlaying,
     isPaused,
+    isInFocusMode,
     playbackFinished,
     hasAudio,
     currentItem,

--- a/src/composables/useGun.js
+++ b/src/composables/useGun.js
@@ -247,7 +247,13 @@ async function syncToGun(key, data) {
     syncStats.lastPushAt = Date.now()
     gun.user().get('openlearn').get(key).put(payload)
     writeSyncMarker()
-    window.dispatchEvent(new CustomEvent('gun-sync', { detail: { key, data, method: 'put' } }))
+    // NOTE: Intentionally no `gun-sync` event dispatch for local pushes.
+    // The source composable already mutated its own reactive state before
+    // calling syncToGun, so re-dispatching would just cause other composables
+    // to re-apply the same data via Object.assign — which re-triggers Vue's
+    // deep watchers (including the LessonDetail progress/settings watchers
+    // that used to break the audio chain mid-playback). The `gun-sync` event
+    // bus is reserved for REMOTE data arriving via pullFromRemote / setupSyncListener.
   } catch (e) {
     console.error('Gun sync error:', e)
   }

--- a/src/composables/useLessonAudioSync.js
+++ b/src/composables/useLessonAudioSync.js
@@ -30,7 +30,7 @@ import { useAudio } from './useAudio'
 
 export function useLessonAudioSync() {
   const {
-    isLoadingAudio, isPlaying, isPaused, playbackFinished, hasAudio,
+    isLoadingAudio, isPlaying, isPaused, isInFocusMode, playbackFinished, hasAudio,
     currentItem, lessonMetadata, isTransitioning, continuousMode,
     lessonTransitionTick,
     initializeAudio, play, pause, cleanup,
@@ -40,23 +40,27 @@ export function useLessonAudioSync() {
   /**
    * Called from the settings-changed deep watcher. Rebuilds the audio queue
    * to reflect new `readAnswers` / `hideLearnedExamples` / active label
-   * settings, but only when playback is NOT active. The composable's own
-   * defensive guard would also skip the rebuild, but making the intent
-   * explicit here keeps the view-layer contract obvious.
+   * settings, but only when playback is NOT active. Early-returns during
+   * focus mode (active playback) so the chain cannot be interrupted.
    */
   async function onSettingsChanged({ lesson, learning, workshop, audioSettings }) {
     if (!lesson) return false
+    // Never touch the audio composable while the chain is running.
+    // The view layer disables the mutating controls anyway, but this is a
+    // belt-and-braces check in case something else fires the watcher.
+    if (isInFocusMode.value) return false
     await initializeAudio(lesson, learning, workshop, audioSettings, { force: true })
     return true
   }
 
   /**
    * Called from the progress deep watcher. Same contract as onSettingsChanged,
-   * but gated on hideLearnedExamples — there is no reason to rebuild when
-   * learned items are visible anyway.
+   * but additionally gated on hideLearnedExamples — there is no reason to
+   * rebuild when learned items are visible anyway.
    */
   async function onProgressChanged({ lesson, learning, workshop, audioSettings }) {
     if (!lesson) return false
+    if (isInFocusMode.value) return false
     if (!audioSettings || !audioSettings.hideLearnedExamples) return false
     await initializeAudio(lesson, learning, workshop, audioSettings, { force: true })
     return true
@@ -136,6 +140,7 @@ export function useLessonAudioSync() {
     isLoadingAudio,
     isPlaying,
     isPaused,
+    isInFocusMode,
     playbackFinished,
     hasAudio,
     currentItem,

--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -157,7 +157,7 @@
               </div>
             </template>
 
-            <template v-else-if="example.type === 'input'">
+            <template v-else-if="example.type === 'input' && !isInFocusMode">
               <div class="mt-2" @click.stop>
                 <Input
                   type="text"
@@ -173,7 +173,7 @@
               </div>
             </template>
 
-            <template v-else-if="example.type === 'multiple-choice'">
+            <template v-else-if="example.type === 'multiple-choice' && !isInFocusMode">
               <div class="mt-2 space-y-2" @click.stop>
                 <label
                   v-for="(option, optIdx) in example.options"
@@ -194,7 +194,7 @@
               </div>
             </template>
 
-            <template v-else-if="example.type === 'select'">
+            <template v-else-if="example.type === 'select' && !isInFocusMode">
               <div class="mt-2 space-y-2" @click.stop>
                 <RadioGroup
                   :model-value="getDraftSelect(example) !== null ? String(getDraftSelect(example)) : undefined"
@@ -225,7 +225,8 @@
                 variant="outline"
                 @click.stop="handleItemClick(item[0])"
                 :class="[
-                  'cursor-pointer transition-all duration-200 text-xs',
+                  'transition-all duration-200 text-xs',
+                  isInFocusMode ? 'cursor-default pointer-events-none opacity-60' : 'cursor-pointer',
                   isItemLearned(learning, workshop, item[0])
                     ? 'bg-green-100 dark:bg-green-800/40 border-green-400 dark:border-green-500/40 opacity-70'
                     : 'bg-sky-50 dark:bg-sky-900/20 border-sky-200 dark:border-sky-500/30 hover:bg-sky-100 dark:hover:bg-sky-800/30 hover:shadow-sm'
@@ -246,7 +247,8 @@
                 :key="label"
                 @click.stop="toggleLabel(label)"
                 :class="[
-                  'cursor-pointer transition-all text-[10px] font-semibold px-2.5 py-0.5 rounded-full',
+                  'transition-all text-[10px] font-semibold px-2.5 py-0.5 rounded-full',
+                  isInFocusMode ? 'cursor-default pointer-events-none opacity-60' : 'cursor-pointer',
                   activeLabel === label
                     ? 'bg-primary text-primary-foreground shadow-sm'
                     : 'bg-primary/10 text-primary dark:bg-primary/20 hover:bg-primary/20 dark:hover:bg-primary/30'
@@ -343,7 +345,8 @@ const { isItemLearned, toggleItemLearned, areAllItemsLearned, progress, setLastV
 // through useLessonAudioSync so the logic is testable without mounting.
 const { jumpToExample } = useAudio()
 const {
-  isLoadingAudio, isPlaying, isPaused, playbackFinished, hasAudio, currentItem,
+  isLoadingAudio, isPlaying, isPaused, isInFocusMode,
+  playbackFinished, hasAudio, currentItem,
   lessonMetadata: audioLessonMetadata,
   isTransitioning, continuousMode, lessonTransitionTick,
   play, pause,
@@ -533,6 +536,8 @@ function getSubmission(example) {
 }
 
 function submitAnswer(example) {
+  // Focus mode: no assessment submissions while playing.
+  if (isInFocusMode.value) return
   const type = example.type || 'qa'
   let userAnswer
 
@@ -628,15 +633,22 @@ function scrollToSection(idx) {
 }
 
 function toggleLabel(label) {
+  // Focus mode: no label changes while playing (would rebuild the audio queue).
+  if (isInFocusMode.value) return
   activeLabel.value = activeLabel.value === label ? null : label
 }
 
 function handleItemClick(itemId) {
+  // Focus mode: no progress mutations while playing.
+  if (isInFocusMode.value) return
   toggleItemLearned(learning.value, workshop.value, itemId)
 }
 
 function handleQuestionClick(example) {
   if (isAssessmentType(example)) return
+  // Focus mode: no answer reveals while playing (purely visual, but keeps
+  // the "locked-down read-only lesson" contract clean).
+  if (isInFocusMode.value) return
   if (!settings.value.showAnswers && (!example.type || example.type === 'qa')) {
     const key = draftKey(example)
     revealedAnswers[key] = !revealedAnswers[key]
@@ -645,6 +657,9 @@ function handleQuestionClick(example) {
 
 function handleExampleClick(example) {
   if (isAssessmentType(example)) return
+  // Focus mode: no jump-to-example clicks (would restart the chain from
+  // a different position and drop the currently playing clip).
+  if (isInFocusMode.value) return
   jumpToExample(example._originalSectionIdx, example._originalExampleIdx, audioSettings.value)
 }
 

--- a/tests/audio.test.js
+++ b/tests/audio.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 // Mock useLessons and useProgress before importing useAudio
 vi.mock('../src/composables/useLessons', () => ({
@@ -793,5 +793,277 @@ describe('continuous play mode', () => {
     audio.isTransitioning.value = false
     audio.cleanup()
     expect(audio.readingQueue.value.length).toBe(0)
+  })
+})
+
+// -----------------------------------------------------------------------------
+// End-to-end playback chain — these are the tests that would have caught the
+// "stops after first section title" bug. They fire the real `onended` handler
+// on each clip and advance the setTimeout between clips, exercising the
+// composable exactly as the browser would.
+// -----------------------------------------------------------------------------
+describe('end-to-end playback chain', () => {
+  let audio
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    audio = useAudio()
+    audio.isTransitioning.value = false
+    audio.disableContinuousMode()
+    audio.cleanup()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const settings = { readAnswers: true, hideLearnedExamples: false, audioSpeed: 1.0 }
+
+  // Helper: advance through the pause between clips and fire the next ended.
+  // Pause durations: 1000ms (lesson-title), 1200ms (section-title), 800/1800 (examples).
+  async function advanceToNextClip() {
+    // Flush any microtasks
+    await vi.advanceTimersByTimeAsync(2000)
+  }
+
+  it('plays a multi-clip lesson all the way through via the onended chain', async () => {
+    const lesson = {
+      title: 'Chain Test',
+      number: 1,
+      _filename: '01-chain',
+      sections: [{
+        title: 'Section One',
+        examples: [
+          { q: 'Q1', a: 'A1' },
+          { q: 'Q2', a: 'A2' },
+        ]
+      }]
+    }
+
+    await audio.initializeAudio(lesson, 'de', 'pt', settings)
+
+    // Queue: [lesson-title, section-title, Q1, A1, Q2, A2] = 6 items
+    expect(audio.readingQueue.value.length).toBe(6)
+
+    audio.play(settings)
+    expect(audio.isPlaying.value).toBe(true)
+    expect(audio.currentItemIndex.value).toBe(0)
+
+    // Fire onended for each clip and verify the chain advances
+    for (let i = 0; i < 5; i++) {
+      const current = audio.currentAudio.value
+      expect(current).toBeTruthy()
+      current._fireEnded()
+      await advanceToNextClip()
+      // After firing ended + advancing the setTimeout, index should have moved
+      expect(audio.currentItemIndex.value).toBe(i + 1)
+    }
+
+    // Fire the last clip's onended — this should trigger end-of-queue handling
+    audio.currentAudio.value._fireEnded()
+    await advanceToNextClip()
+
+    expect(audio.playbackFinished.value).toBe(true)
+    expect(audio.isPlaying.value).toBe(false)
+  })
+
+  it('does NOT break the chain when progress is mutated mid-playback', async () => {
+    // Regression: a gun-sync event (or any deep mutation on progress) used
+    // to trigger initializeAudio({force:true}) → clobber isPlaying → dead chain.
+    const { ref, watch } = await import('vue')
+    const progress = ref({})
+    const audioSettings = ref({ ...settings, hideLearnedExamples: true })
+
+    const lesson = {
+      title: 'Progress Chain',
+      number: 2,
+      _filename: '02-progress',
+      sections: [{
+        title: 'S',
+        examples: [{ q: 'Q1', a: 'A1' }, { q: 'Q2', a: 'A2' }]
+      }]
+    }
+
+    await audio.initializeAudio(lesson, 'de', 'pt', audioSettings.value)
+    audio.play(audioSettings.value)
+
+    // Wire the LessonDetail-style deep watcher (this is what used to break things)
+    const { useLessonAudioSync } = await import('../src/composables/useLessonAudioSync')
+    const { onProgressChanged } = useLessonAudioSync()
+    watch(progress, () => onProgressChanged({
+      lesson, learning: 'de', workshop: 'pt', audioSettings: audioSettings.value
+    }), { deep: true })
+
+    // Play clip 1 end → advance
+    audio.currentAudio.value._fireEnded()
+    await advanceToNextClip()
+    expect(audio.currentItemIndex.value).toBe(1)
+
+    // Simulate a mutation that would normally trigger initializeAudio
+    progress.value['de:pt'] = { hello: Date.now() }
+    await vi.advanceTimersByTimeAsync(10)
+
+    // Chain must still be alive
+    expect(audio.isPlaying.value).toBe(true)
+
+    // Play clip 2 end → advance — this must still work
+    audio.currentAudio.value._fireEnded()
+    await advanceToNextClip()
+    expect(audio.currentItemIndex.value).toBe(2)
+  })
+
+  it('does NOT break the chain when two initializeAudio calls race', async () => {
+    // Regression: concurrent initializeAudio calls used to interleave.
+    // The single-flight lock now serializes them.
+    const lesson = {
+      title: 'Race Test',
+      number: 3,
+      _filename: '03-race',
+      sections: [{ title: 'S', examples: [{ q: 'Q', a: 'A' }] }]
+    }
+
+    // First call, then immediately a second force call — they must NOT clobber.
+    const p1 = audio.initializeAudio(lesson, 'de', 'pt', settings)
+    const p2 = audio.initializeAudio(lesson, 'de', 'pt', settings, { force: true })
+    await Promise.all([p1, p2])
+
+    audio.play(settings)
+    expect(audio.isPlaying.value).toBe(true)
+
+    const firstClip = audio.currentAudio.value
+    expect(firstClip).toBeTruthy()
+
+    firstClip._fireEnded()
+    await advanceToNextClip()
+
+    // Chain must still be advancing
+    expect(audio.isPlaying.value).toBe(true)
+    expect(audio.currentItemIndex.value).toBeGreaterThan(0)
+  })
+
+  it('skips assessment items from the audio queue', async () => {
+    // Playing mode is for listening — assessments are hidden and skipped.
+    const lesson = {
+      title: 'Mixed',
+      number: 4,
+      _filename: '04-mixed',
+      sections: [{
+        title: 'S',
+        examples: [
+          { q: 'Plain question', a: 'Plain answer' },           // type: qa (default)
+          { type: 'input', q: 'Type this', a: 'hello' },         // assessment — skipped
+          { type: 'multiple-choice', q: 'Pick one', options: [] }, // assessment — skipped
+          { type: 'select', q: 'Select', options: [] },          // assessment — skipped
+          { q: 'Another plain', a: 'Also plain' },
+        ]
+      }]
+    }
+
+    await audio.initializeAudio(lesson, 'de', 'pt', settings)
+
+    // Queue should contain: lesson-title, section-title, Q1, A1, Q5, A5 = 6
+    // (NOT the 3 assessment items)
+    expect(audio.readingQueue.value.length).toBe(6)
+    const questions = audio.readingQueue.value.filter(i => i.type === 'question')
+    expect(questions).toHaveLength(2)
+    expect(questions[0].text).toBe('Plain question')
+    expect(questions[1].text).toBe('Another plain')
+  })
+})
+
+// -----------------------------------------------------------------------------
+// Focus mode — single flag that puts the lesson into listen-only state.
+// -----------------------------------------------------------------------------
+describe('focus mode (playing = read-only)', () => {
+  let audio
+
+  beforeEach(() => {
+    audio = useAudio()
+    audio.isTransitioning.value = false
+    audio.disableContinuousMode()
+    audio.cleanup()
+  })
+
+  const settings = { readAnswers: true, hideLearnedExamples: false, audioSpeed: 1.0 }
+  const lesson = {
+    title: 'Focus Test',
+    number: 1,
+    _filename: '01-focus',
+    sections: [{ title: 'S', examples: [{ q: 'Q', a: 'A' }] }]
+  }
+
+  it('is false when not playing', async () => {
+    await audio.initializeAudio(lesson, 'de', 'pt', settings)
+    expect(audio.isInFocusMode.value).toBe(false)
+  })
+
+  it('is true while playing', async () => {
+    await audio.initializeAudio(lesson, 'de', 'pt', settings)
+    audio.play(settings)
+    expect(audio.isInFocusMode.value).toBe(true)
+  })
+
+  it('is false after pause', async () => {
+    await audio.initializeAudio(lesson, 'de', 'pt', settings)
+    audio.play(settings)
+    audio.pause()
+    expect(audio.isInFocusMode.value).toBe(false)
+  })
+
+  it('is false after stop', async () => {
+    await audio.initializeAudio(lesson, 'de', 'pt', settings)
+    audio.play(settings)
+    audio.stop()
+    expect(audio.isInFocusMode.value).toBe(false)
+  })
+})
+
+describe('useLessonAudioSync: focus mode gates watchers', () => {
+  let audio
+  let sync
+
+  beforeEach(async () => {
+    audio = useAudio()
+    audio.isTransitioning.value = false
+    audio.disableContinuousMode()
+    audio.cleanup()
+    const { useLessonAudioSync } = await import('../src/composables/useLessonAudioSync')
+    sync = useLessonAudioSync()
+  })
+
+  const settings = { readAnswers: true, hideLearnedExamples: true, audioSpeed: 1.0 }
+  const lesson = {
+    title: 'Gate Test',
+    number: 1,
+    _filename: '01-gate',
+    sections: [{ title: 'S', examples: [{ q: 'Q', a: 'A' }] }]
+  }
+
+  it('onSettingsChanged is a no-op during focus mode', async () => {
+    await audio.initializeAudio(lesson, 'de', 'pt', settings)
+    audio.play(settings)
+    // focus mode active
+    const result = await sync.onSettingsChanged({
+      lesson, learning: 'de', workshop: 'pt', audioSettings: settings
+    })
+    expect(result).toBe(false)
+  })
+
+  it('onProgressChanged is a no-op during focus mode', async () => {
+    await audio.initializeAudio(lesson, 'de', 'pt', settings)
+    audio.play(settings)
+    const result = await sync.onProgressChanged({
+      lesson, learning: 'de', workshop: 'pt', audioSettings: settings
+    })
+    expect(result).toBe(false)
+  })
+
+  it('onSettingsChanged runs normally when not in focus mode', async () => {
+    await audio.initializeAudio(lesson, 'de', 'pt', settings)
+    // NOT playing
+    const result = await sync.onSettingsChanged({
+      lesson, learning: 'de', workshop: 'pt', audioSettings: settings
+    })
+    expect(result).toBe(true)
   })
 })

--- a/tests/gun-sync.test.js
+++ b/tests/gun-sync.test.js
@@ -366,19 +366,25 @@ describe('Gun Sync', () => {
   })
 
   describe('gun-sync events', () => {
-    it('dispatches put event on syncToGun', async () => {
+    it('does NOT dispatch gun-sync on local syncToGun pushes', async () => {
+      // Regression: local pushes used to dispatch a gun-sync event, which
+      // re-notified useSettings/useProgress/useAssessments listeners with
+      // the same data they had just written. That Object.assign re-triggered
+      // Vue deep watchers (e.g. the LessonDetail progress watcher) and
+      // caused the audio chain to be rebuilt mid-playback. The event bus
+      // is now reserved for REMOTE data only.
       const gun = await loginAndGetGun()
       const events = []
       const handler = (e) => events.push(e.detail)
       window.addEventListener('gun-sync', handler)
 
       await gun.syncToGun('settings', { darkMode: true })
+      await new Promise(r => setTimeout(r, 10))
 
       window.removeEventListener('gun-sync', handler)
 
-      const putEvents = events.filter(e => e.method === 'put' && e.key === 'settings')
-      expect(putEvents).toHaveLength(1)
-      expect(putEvents[0].data).toEqual({ darkMode: true })
+      const settingsEvents = events.filter(e => e.key === 'settings')
+      expect(settingsEvents).toHaveLength(0)
     })
 
     it('dispatches once events on pull', async () => {


### PR DESCRIPTION
## Summary

Fixes the \"play button stops after one clip\" bug via four layered fixes and introduces a **focus mode** flag that disables all state-mutating UI during playback — collapsing the test matrix from \"every mutation × every sync path × every watcher\" down to a single check.

### Root causes identified

1. **Concurrent \`initializeAudio\` race** — two calls could race past the guards and clobber \`isPlaying\` mid-playback. Fixed with a single-flight lock and a post-await re-check.

2. **\`syncToGun\` dispatched \`gun-sync\` on local pushes** — re-triggered \`useSettings\`/\`useProgress\`/\`useAssessments\` listeners → Vue deep watchers → \`initializeAudio({force:true})\` → dead chain. The event bus is now reserved for REMOTE data only.

3. **\`play()\` guard used \`currentAudio.paused\`** — flips true between clips (after onended), letting re-entrant play() calls double-advance the queue. Now guards on \`isPlaying && !isPaused\`.

4. **\`attachPlaybackHandlers\` captured settings by value** — mid-playback setting changes didn't apply. Now reads from \`latestAudioSettingsRef\` on every callback.

### Focus mode

New \`isInFocusMode = isPlaying && !isPaused\` computed ref. During focus mode:

| Disabled | Hidden | Skipped from audio queue |
|----------|--------|--------------------------|
| handleItemClick (toggle learned) | All assessment input templates | All assessment items |
| handleQuestionClick (reveal answer) | | |
| handleExampleClick (jumpToExample) | | |
| toggleLabel (activeLabel mutation) | | |
| submitAnswer (assessment submission) | | |

\`useLessonAudioSync.onSettingsChanged\` / \`onProgressChanged\` also early-return during focus mode as a belt-and-braces guard.

### Tests (218 total, 11 new)

- **End-to-end chain test**: plays a 6-clip lesson via real \`onended\` firing with fake timers — the test that would have caught the bug.
- **Progress-mutation-during-playback regression test**
- **Concurrent \`initializeAudio\` race test**
- **Assessment skipping from audio queue**
- **Focus mode state transitions** (4 tests)
- **\`useLessonAudioSync\` focus gates** (3 tests)
- Updated gun-sync test to verify local pushes do NOT emit gun-sync events

## Test plan
- [ ] Click play on a lesson, audio plays all the way through all clips
- [ ] During playback, assessments are hidden and not read out loud
- [ ] During playback, toggling learned items / labels has no effect (ghost cursor, dimmed badges)
- [ ] \`npx vitest --run\` — 218 tests pass