### PR TITLE
fix: preserve scroll on label filter toggle

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -101,7 +101,17 @@ const routes = [
 const router = createRouter({
   history: createWebHashHistory(import.meta.env.BASE_URL),
   routes,
-  scrollBehavior() {
+  scrollBehavior(to, from) {
+    // Preserve scroll position when only the query string changes on the
+    // same route (e.g. activating/clearing the label filter on a lesson).
+    // Otherwise scroll to top on navigation.
+    if (
+      to.name === from.name &&
+      JSON.stringify(to.params) === JSON.stringify(from.params) &&
+      to.path === from.path
+    ) {
+      return false
+    }
     return { top: 0 }
   }
 })


### PR DESCRIPTION
## Summary
Vue Router's \`scrollBehavior\` fired on every navigation, including the \`router.replace({ query })\` calls from the activeLabel watcher. That meant activating or clearing a label filter scrolled the lesson back to the top of the (often large) header image — confusing UX.

Now \`scrollBehavior\` detects query-only changes on the same route and returns \`false\` to keep the current scroll position. Scroll-to-top still happens on real navigations (lesson → lesson, lesson → results, etc.).

## Test plan
- [ ] Open a long lesson, scroll down, click a label → no scroll jump
- [ ] Click \"Take the test\" / \"Open tests\" → no scroll jump
- [ ] Clear the filter (✕) → no scroll jump
- [ ] Click Next Lesson → scrolls to top (real navigation)