### PR TITLE
feat: hide distractions and dim navigation in focus mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,11 @@
     <header v-if="!isHomePage && !isStoryMode" class="bg-primary text-white pt-1 pb-2 md:py-4 px-4 relative sticky z-50" style="top: env(safe-area-inset-top, 0px)">
       <div class="flex items-center justify-between gap-2">
         <!-- Left side: language dropdown + nav buttons -->
-        <div class="flex items-center gap-2 min-w-fit">
+        <!-- Dimmed and disabled during focus mode (audio playback) so the
+             user can only interact with play/pause until they pause. -->
+        <div
+          class="flex items-center gap-2 min-w-fit transition-opacity"
+          :class="isInFocusMode ? 'opacity-40 pointer-events-none' : ''">
           <!-- Language dropdown (only on workshop overview) -->
           <div v-if="isWorkshopOverview && learningLanguages.length > 0" class="relative">
             <button
@@ -110,6 +114,12 @@
             </span>
           </Button>
 
+          <!-- All non-play right-side buttons. Dimmed and disabled in
+               focus mode (audio playback) so the play/pause button stays
+               the only interactive control. -->
+          <div
+            class="flex items-center gap-2 transition-opacity"
+            :class="isInFocusMode ? 'opacity-40 pointer-events-none' : ''">
           <!-- Story mode button (visible on lesson/overview pages) -->
           <Button
             v-if="canEnterStoryMode"
@@ -209,6 +219,7 @@
               </div>
             </div>
           </div>
+          </div><!-- end dimmed right-side group -->
         </div>
       </div>
     </header>
@@ -222,8 +233,9 @@
       </RouterView>
     </div>
 
-    <!-- Footer -->
-    <footer v-if="!isStoryMode" class="border-t border-border px-8 py-4 md:rounded-b-xl" :class="contentBgClass">
+    <!-- Footer — dimmed and disabled during focus mode (audio playback) -->
+    <footer v-if="!isStoryMode" class="border-t border-border px-8 py-4 md:rounded-b-xl transition-opacity"
+      :class="[contentBgClass, isInFocusMode ? 'opacity-40 pointer-events-none' : '']">
       <div class="flex items-center gap-4 text-sm">
         <a href="#/" class="text-primary hover:underline whitespace-nowrap">Home</a>
         <a
@@ -285,7 +297,7 @@ const appVersion = __APP_VERSION__
 const lastPR = __APP_LAST_PR__
 
 const {
-  isLoadingAudio, isPlaying, play, pause, resume,
+  isLoadingAudio, isPlaying, isInFocusMode, play, pause, resume,
   continuousMode, enableContinuousMode, disableContinuousMode,
 } = useAudio()
 const { settings } = useSettings()

--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-if="lesson">
-      <div v-if="lesson.image" class="mb-5 rounded-lg overflow-hidden shadow-sm">
+      <div v-if="lesson.image && !isInFocusMode" class="mb-5 rounded-lg overflow-hidden shadow-sm">
         <img
           :src="resolveImagePath(lesson.image)"
           :alt="lesson.image_caption || lesson.title"
@@ -15,7 +15,7 @@
       <h2 class="text-3xl font-bold text-foreground mb-3">
         {{ lesson.title }}
       </h2>
-      <p v-if="lesson.description" class="text-muted-foreground mb-5 text-lg">
+      <p v-if="lesson.description && !isInFocusMode" class="text-muted-foreground mb-5 text-lg">
         {{ lesson.description }}
       </p>
 
@@ -72,7 +72,7 @@
           </div>
         </CardHeader>
         <CardContent class="p-0">
-          <div v-if="section.video && !activeLabel" class="mb-4">
+          <div v-if="section.video && !activeLabel && !isInFocusMode" class="mb-4">
             <iframe
               v-if="isYouTubeUrl(section.video)"
               :src="normalizeVideoUrl(section.video)"
@@ -90,7 +90,7 @@
             </video>
           </div>
 
-          <div v-if="section.image && !activeLabel" class="mb-4">
+          <div v-if="section.image && !activeLabel && !isInFocusMode" class="mb-4">
             <img
               :src="resolveImagePath(section.image)"
               :alt="section.image_caption || section.title"
@@ -124,7 +124,7 @@
           </Teleport>
 
           <div
-            v-if="section.explanation && !activeLabel"
+            v-if="section.explanation && !activeLabel && !isInFocusMode"
             class="bg-muted/60 p-4 rounded-lg mb-4 border-l-4 border-primary/30 prose prose-sm dark:prose-invert max-w-none"
             v-html="DOMPurify.sanitize(marked(section.explanation))">
           </div>
@@ -275,7 +275,7 @@
             </div>
               </div><!-- end flex-1 text column -->
 
-              <div v-if="example.image" class="flex-shrink-0 w-32 sm:w-40">
+              <div v-if="example.image && !isInFocusMode" class="flex-shrink-0 w-32 sm:w-40">
                 <img
                   :src="resolveImagePath(example.image)"
                   :alt="example.image_caption || example.q"


### PR DESCRIPTION
## Summary
Lock down the lesson view during auto-play so the user has a pure listening experience.

### Hidden in focus mode
- Lesson header image
- Lesson description
- Section header images
- Section videos (YouTube + native)
- Section explanations (markdown)
- Per-example images

### Dimmed and disabled in focus mode
- Left-side nav buttons (back, language dropdown)
- Right-side nav buttons (story, results/items toggles, burger menu)
- Footer (next lesson button, home/guide/feedback links)

### Stays interactive
- Play/pause button (the only way to exit focus mode)

Implemented as plain Vue \`v-if\` and class bindings on \`isInFocusMode\`.

## Test plan
- [ ] Click play on a lesson with header image, section videos, explanations → all hidden during playback
- [ ] Try clicking back button / settings / next lesson during playback → no effect, dimmed visually
- [ ] Click pause → all elements reappear, navigation works
- [ ] \`npx vitest --run\` — 218 tests pass