### PR TITLE
fix: settings reset on page load (regression from #241)

### DIFF
--- a/src/composables/useSettings.js
+++ b/src/composables/useSettings.js
@@ -49,6 +49,13 @@ function loadSettings() {
     // Apply default dark mode on first load
     applyDarkMode(settings.value.darkMode)
   }
+  // Sync the audio debug flag to whatever we just loaded. Must happen
+  // AFTER the settings ref is populated — never via an `immediate: true`
+  // watcher on showDebugOverlay, because that fires at watcher-register
+  // time with the default value and would cause saveSettings() to clobber
+  // the user's saved settings before we ever read them (regressed via #241,
+  // fixed right after).
+  setAudioDebugEnabled(settings.value.showDebugOverlay)
 }
 
 // Initialize watchers only once
@@ -90,8 +97,13 @@ function initializeWatchers() {
   watch(() => settings.value.showDebugOverlay, (enabled) => {
     saveSettings()
     // Keep the audio-debug event log in sync so the overlay gets populated.
+    // NOTE: no `immediate: true` here — that would fire at watcher-register
+    // time, call saveSettings() with the DEFAULT settings, and overwrite
+    // the user's saved settings before loadSettings() ever gets to read
+    // them. Initial sync with showDebugOverlay is done inside loadSettings()
+    // instead. See regression test in tests/merge-settings.test.js.
     setAudioDebugEnabled(enabled)
-  }, { immediate: true })
+  })
 
   // Listen for real-time Gun sync events from other devices/tabs
   window.addEventListener('gun-sync', (e) => {

--- a/tests/merge-settings.test.js
+++ b/tests/merge-settings.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // Mock useGun before importing useSettings
 vi.mock('../src/composables/useGun', () => ({
@@ -7,18 +7,29 @@ vi.mock('../src/composables/useGun', () => ({
     syncToGun: vi.fn()
   })
 }))
-
-const { useSettings } = await import('../src/composables/useSettings')
+vi.mock('../src/composables/useAudioDebug', () => ({
+  setAudioDebugEnabled: vi.fn()
+}))
 
 describe('useSettings', () => {
-  it('loads settings from localStorage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    // Blow away the module so isInitialized + the watchers reset between
+    // tests. This is what makes the "settings persistence on boot" test
+    // actually exercise the watcher-register path.
+    vi.resetModules()
+  })
+
+  it('loads settings from localStorage', async () => {
+    const { useSettings } = await import('../src/composables/useSettings')
     const { settings, loadSettings } = useSettings()
     loadSettings()
     expect(settings.value).toBeDefined()
     expect(typeof settings.value.darkMode).toBe('boolean')
   })
 
-  it('saves and loads settings round-trip', () => {
+  it('saves and loads settings round-trip', async () => {
+    const { useSettings } = await import('../src/composables/useSettings')
     const { settings, saveSettings, loadSettings } = useSettings()
 
     settings.value.darkMode = true
@@ -29,5 +40,45 @@ describe('useSettings', () => {
     const stored = JSON.parse(localStorage.getItem('settings'))
     expect(stored.darkMode).toBe(true)
     expect(stored.audioSpeed).toBe(0.8)
+  })
+
+  // Regression: #241 introduced a bug where settings were reset on every
+  // page load. The showDebugOverlay watcher was registered with
+  // `{ immediate: true }`, which fired synchronously at watcher-register
+  // time with the DEFAULT value and called saveSettings() — writing the
+  // defaults to localStorage BEFORE loadSettings() ever got to read them.
+  // Every page load nuked the user's saved settings.
+  it('does NOT overwrite persisted settings when loadSettings is called (regression: #241)', async () => {
+    // Simulate a user that previously saved some non-default settings
+    localStorage.setItem('settings', JSON.stringify({
+      showAnswers: false,
+      showLearningItems: false,
+      showLabels: false,
+      darkMode: true,
+      audioSpeed: 0.6,
+      readAnswers: false,
+      hideLearnedExamples: false,
+      showDebugOverlay: false,
+    }))
+
+    // Fresh module import — this mirrors the main.js boot sequence and
+    // runs initializeWatchers for the first time, so if any watcher has
+    // `{ immediate: true }` with a saveSettings side effect, it would
+    // overwrite our pre-seeded localStorage HERE.
+    const { useSettings } = await import('../src/composables/useSettings')
+    const { settings, loadSettings } = useSettings()
+    loadSettings()
+
+    // The loaded settings MUST reflect what we previously stored — not the
+    // hardcoded defaults.
+    expect(settings.value.showAnswers).toBe(false)
+    expect(settings.value.audioSpeed).toBe(0.6)
+    expect(settings.value.darkMode).toBe(true)
+    expect(settings.value.readAnswers).toBe(false)
+
+    // localStorage must still hold the original values (not clobbered)
+    const stored = JSON.parse(localStorage.getItem('settings'))
+    expect(stored.showAnswers).toBe(false)
+    expect(stored.audioSpeed).toBe(0.6)
   })
 })


### PR DESCRIPTION
Regression from #241. Fast fix + verified regression test.

## The bug

PR #241 added a watcher with `{ immediate: true }` on `settings.showDebugOverlay` in `src/composables/useSettings.js` so that flipping the toggle would also enable the audio-debug event log. `{ immediate: true }` fires the callback **synchronously at watcher-register time** with the *default* value, and the callback calls `saveSettings()` — which writes the entire hardcoded default settings object to localStorage.

Failure sequence on every page load:

1. `main.js:13` calls `useSettings().loadSettings()`
2. `useSettings()` runs `initializeWatchers()` — which registers the immediate watcher
3. The immediate watcher fires synchronously with `settings.value = { hardcoded defaults }`
4. `saveSettings()` writes those defaults to localStorage, **clobbering** whatever the user had saved
5. `loadSettings()` reads localStorage — but it now contains the defaults we just wrote, so `settings.value = defaults`

Every page load reset the user's saved settings.

## Fix

Drop `{ immediate: true }` from the watcher. Do the initial `setAudioDebugEnabled(settings.value.showDebugOverlay)` call inside `loadSettings()` instead, **after** the settings ref has been populated from localStorage.

## Regression test

New test in `tests/merge-settings.test.js`:

```js
it('does NOT overwrite persisted settings when loadSettings is called (regression: #241)', async () => {
  localStorage.setItem('settings', JSON.stringify({
    showAnswers: false, audioSpeed: 0.6, darkMode: true, ...
  }))
  const { useSettings } = await import('../src/composables/useSettings')
  const { settings, loadSettings } = useSettings()
  loadSettings()
  expect(settings.value.showAnswers).toBe(false)
  expect(settings.value.audioSpeed).toBe(0.6)
  // ...
})
```

The test uses `vi.resetModules()` + dynamic import in `beforeEach` so the `isInitialized` flag resets and `initializeWatchers` runs fresh each time, mirroring the main.js boot sequence.

**Verified**: I temporarily re-added `{ immediate: true }` locally and the test **failed** with `expected true to be false` on the `showAnswers` assertion (confirming it catches the exact bug). Then removed the revert and the test **passed**.

## Test plan

- [x] `npx vitest run tests/merge-settings.test.js` → 3 tests passing
- [x] Full suite `npx vitest run` → **17 files, 235 tests, all passing** (was 234)
- [x] `pnpm build` → clean
- [ ] Manual: reload a page, change a setting, reload again — setting should persist

https://claude.ai/code/session_01VdrygUmC14KXArS6Bu89Ed