### PR TITLE
fix: continuous play on iOS — remove setTimeout debounce + autoplay (#246)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -679,27 +679,17 @@ function togglePlayPause() {
 // same enableContinuousMode path; here we just toggle continuous mode on/off.
 // If there is no active provider (e.g. lessons not loaded yet), the first
 // double-click is a no-op — LessonDetail re-registers the provider on mount.
-const APP_PLAY_DOUBLE_CLICK_DELAY = 260
-let appPlayClickTimer = null
-
+// Click: toggle play/pause IMMEDIATELY inside the gesture — no setTimeout.
+// iOS requires audio.play() from a direct gesture handler (#246).
 function handleAppPlayClick() {
-  if (appPlayClickTimer) return
-  appPlayClickTimer = setTimeout(() => {
-    appPlayClickTimer = null
-    togglePlayPause()
-  }, APP_PLAY_DOUBLE_CLICK_DELAY)
+  togglePlayPause()
 }
 
 function handleAppPlayDoubleClick() {
-  if (appPlayClickTimer) {
-    clearTimeout(appPlayClickTimer)
-    appPlayClickTimer = null
-  }
+  // The first click already toggled play. Now just toggle continuous mode.
   if (continuousMode.value) {
     disableContinuousMode()
   } else {
-    // Signal LessonDetail to turn on continuous mode (it owns the lesson list
-    // and therefore the next-lesson provider). Dispatch a custom event.
     window.dispatchEvent(new CustomEvent('open-learn:start-continuous-play'))
   }
 }

--- a/src/composables/useLessonAudioSync.js
+++ b/src/composables/useLessonAudioSync.js
@@ -82,24 +82,14 @@ export function useLessonAudioSync() {
    */
   async function onLessonMount({
     lesson, learning, workshop, audioSettings,
-    autoplay = false,
-    continuousNextLessonProvider = null,
   }) {
     if (!lesson) return { started: false }
 
     await initializeAudio(lesson, learning, workshop, audioSettings)
 
-    // Legacy path: if a provider closure was passed AND continuous mode is
-    // already active, re-register it. New callers should use setWorkshopLessons
-    // instead and leave continuousNextLessonProvider undefined.
-    if (continuousMode.value && continuousNextLessonProvider) {
-      enableContinuousMode(continuousNextLessonProvider)
-    }
-
-    if (autoplay && !isPlaying.value) {
-      play(audioSettings)
-      return { started: true }
-    }
+    // No autoplay from URL — iOS rejects play() outside a user gesture,
+    // and the auto-advance feature that set ?autoplay=true was removed.
+    // The user must click the play button to start.
     return { started: false }
   }
 

--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -740,32 +740,26 @@ function togglePlayPause() {
   }
 }
 
-// Debounced click handler so a double click does not also fire a single click
-// that would pause playback right after continuous mode starts.
-let playClickTimer = null
-const PLAY_DOUBLE_CLICK_DELAY = 260 // ms
-
+// Click: toggle play/pause IMMEDIATELY inside the gesture — no setTimeout.
+// iOS requires audio.play() to be called from a direct gesture handler;
+// the old 260ms debounce timer put play() inside a setTimeout callback
+// which iOS rejected with NotAllowedError (#246).
+//
+// Double-click: the first click already starts playback. The dblclick
+// handler just toggles continuous mode on top of the running chain.
 function handlePlayButtonClick() {
-  if (playClickTimer) return // double click in progress
-  playClickTimer = setTimeout(() => {
-    playClickTimer = null
-    togglePlayPause()
-  }, PLAY_DOUBLE_CLICK_DELAY)
+  togglePlayPause()
 }
 
 function handlePlayButtonDoubleClick() {
-  if (playClickTimer) {
-    clearTimeout(playClickTimer)
-    playClickTimer = null
+  // Double-click just toggles continuous mode. The user then clicks
+  // once to start playing. This avoids the "two clicks = play then
+  // pause" issue and keeps the gesture context clean for iOS.
+  if (continuousMode.value) {
+    disableContinuousMode()
+  } else {
+    enableContinuousMode()
   }
-  startContinuousPlay()
-}
-
-function startContinuousPlay() {
-  // After fix C for #240, the audio composable resolves the next lesson
-  // itself via setWorkshopLessons (already called in loadCurrentLesson).
-  // No closure to pass.
-  toggleContinuousPlay({ audioSettings: audioSettings.value })
 }
 
 const playButtonTitle = computed(() => {
@@ -914,8 +908,8 @@ function handleKeydown(e) {
 // Listener for "start continuous play" requests dispatched by App.vue's
 // desktop play button (it doesn't own the lesson list, so it delegates here).
 function handleStartContinuousRequest() {
-  if (lesson.value) {
-    startContinuousPlay()
+  if (lesson.value && !continuousMode.value) {
+    enableContinuousMode()
   }
 }
 
@@ -971,7 +965,6 @@ async function loadCurrentLesson() {
       learning: currentLearning,
       workshop: currentWorkshop,
       audioSettings: audioSettings.value,
-      autoplay: !!route.query.autoplay,
     })
     restoreDraftsFromSaved()
 
@@ -1010,11 +1003,6 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', handleKeydown)
   window.removeEventListener('open-learn:start-continuous-play', handleStartContinuousRequest)
-
-  if (playClickTimer) {
-    clearTimeout(playClickTimer)
-    playClickTimer = null
-  }
 
   // Delegate the "should we tear down?" decision to the composable —
   // it skips cleanup during continuous-mode transitions so iOS keeps the

--- a/tests/lesson-audio-sync.test.js
+++ b/tests/lesson-audio-sync.test.js
@@ -81,24 +81,15 @@ describe('useLessonAudioSync', () => {
   // --- onLessonMount ---
 
   describe('onLessonMount', () => {
-    it('initializes audio and does not autoplay by default', async () => {
+    it('initializes audio without autoplay (autoplay removed for iOS)', async () => {
       const result = await sync.onLessonMount({
         lesson: lesson1, learning: 'de', workshop: 'pt',
-        audioSettings: settings, autoplay: false,
+        audioSettings: settings,
       })
       expect(result.started).toBe(false)
       expect(audio.isPlaying.value).toBe(false)
       expect(audio.hasAudio.value).toBe(true)
       expect(audio.lessonMetadata.value.number).toBe(1)
-    })
-
-    it('autoplays when autoplay=true', async () => {
-      const result = await sync.onLessonMount({
-        lesson: lesson1, learning: 'de', workshop: 'pt',
-        audioSettings: settings, autoplay: true,
-      })
-      expect(result.started).toBe(true)
-      expect(audio.isPlaying.value).toBe(true)
     })
 
     it('no-ops when the composable already shows the same lesson', async () => {
@@ -125,7 +116,7 @@ describe('useLessonAudioSync', () => {
 
       await sync.onLessonMount({
         lesson: lesson1, learning: 'de', workshop: 'pt',
-        audioSettings: settings, autoplay: true,
+        audioSettings: settings,
       })
 
       // Position and isPlaying must be preserved (no restart, no index reset)

--- a/tests/lesson-detail.test.js
+++ b/tests/lesson-detail.test.js
@@ -222,9 +222,11 @@ describe('LessonDetail.vue — component mount tests', () => {
     expect(audio.hasAudio.value).toBe(true)
   })
 
-  it('autoplays when mounted with ?autoplay=true', async () => {
+  it('never autoplays from URL (iOS requires user gesture)', async () => {
+    // Autoplay from ?autoplay=true was removed because iOS rejects play()
+    // outside a user gesture handler. The user must click play.
     const { audio } = await mountLessonDetail({ lessonNumber: 1, query: { autoplay: 'true' } })
-    expect(audio.isPlaying.value).toBe(true)
+    expect(audio.isPlaying.value).toBe(false)
   })
 
   it('does not autoplay without the query flag', async () => {
@@ -233,14 +235,13 @@ describe('LessonDetail.vue — component mount tests', () => {
   })
 
   it('progress mutation during playback does NOT break the audio chain', async () => {
-    // This is THE regression test: mount LessonDetail, start playing, then
+    // Regression test: mount LessonDetail, start playing manually, then
     // deeply mutate progress (simulating a remote Gun sync tick) and verify
     // the view's watcher does not tear down audio mid-playback.
-    const { audio } = await mountLessonDetail({
-      lessonNumber: 1,
-      query: { autoplay: 'true' },
-    })
+    const { audio } = await mountLessonDetail({ lessonNumber: 1 })
 
+    // Simulate the user clicking play (manual gesture)
+    await audio.play({ readAnswers: true, hideLearnedExamples: true, audioSpeed: 1.0 })
     expect(audio.isPlaying.value).toBe(true)
     audio.currentItemIndex.value = 2 // pretend we're mid-queue
     const queueRef = audio.readingQueue.value


### PR DESCRIPTION
Fixes #246.

## Root causes

**1. setTimeout debounce broke iOS gesture context**

The play button used a 260ms `setTimeout` to distinguish single from double click. On iOS, the gesture activation expires after ~5 seconds — but more critically, `setTimeout` callbacks are NOT in the gesture context at all. So `play()` was called from a timer, not from the click handler, and iOS rejected it with `NotAllowedError`.

**2. `?autoplay=true` in the URL triggered play from `onMounted`**

The old auto-advance feature set `?autoplay=true` in the URL when navigating to the next lesson. `onLessonMount` called `play()` from inside `onMounted` — not from a user gesture — so iOS always rejected it. The auto-advance feature was already removed, but the autoplay code path remained.

## Fix

- **Click** = `togglePlayPause()` immediately, inside the gesture handler. No setTimeout.
- **Double-click** = toggle continuous mode only. No play.
- The user double-clicks to enable continuous mode, then clicks to start playing.
- Removed the `autoplay` parameter from `onLessonMount` entirely.

## Interaction model

| Action | Effect |
|---|---|
| Click (not playing) | Start playing current lesson |
| Click (playing) | Pause |
| Double-click | Toggle continuous mode badge on/off |
| Click after enabling continuous mode | Start playing; auto-advances at lesson end |

https://claude.ai/code/session_01VdrygUmC14KXArS6Bu89Ed