### PR TITLE
fix: preserve workshop list order on favorite/active (#248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-04-12
+
+### Fixes
+
+#### Workshops springen nicht mehr beim Favorisieren oder Abhaken (#248)
+- Workshop-Liste behält die ursprüngliche Reihenfolge aus der Quelle
+- Kein automatisches Umsortieren nach aktiv/favorit/Bild mehr
+
 ## 2026-04-11
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Fixes
 
-#### Workshops springen nicht mehr beim Favorisieren oder Abhaken (#248)
+#### Workshops und Lektionen springen nicht mehr beim Favorisieren oder Abhaken (#248)
 - Workshop-Liste behält die ursprüngliche Reihenfolge aus der Quelle
-- Kein automatisches Umsortieren nach aktiv/favorit/Bild mehr
+- Lektionen bleiben an ihrer Stelle wenn sie als erledigt markiert oder favorisiert werden
+- Kein automatisches Umsortieren nach aktiv/favorit/erledigt mehr
 
 ## 2026-04-11
 

--- a/specs/navigation-and-ux.md
+++ b/specs/navigation-and-ux.md
@@ -31,7 +31,7 @@ The top navigation bar adapts to the current page:
 
 ## Workshop Favorites and Sorting
 
-Learners can mark workshops as favorites. Favorited workshops appear at the top of the workshop list, making it fast to access frequently used content. Workshops can also be sorted to match the learner's preference.
+Learners can mark workshops and lessons as favorites. Favorites are visually highlighted but stay in their original position — the list never reorders automatically. Completed lessons also stay in place.
 
 ## Dark Mode
 

--- a/src/components/LearningPath.vue
+++ b/src/components/LearningPath.vue
@@ -94,21 +94,7 @@ const completedRatio = computed(() => {
 })
 
 const sortedLessons = computed(() => {
-  const lessons = [...props.lessons]
-  const favSet = new Set(props.favorites)
-
-  return lessons.sort((a, b) => {
-    const aIsFav = favSet.has(a.number)
-    const bIsFav = favSet.has(b.number)
-
-    if (aIsFav && bIsFav) {
-      return props.favorites.indexOf(a.number) - props.favorites.indexOf(b.number)
-    }
-    if (aIsFav && !bIsFav) return -1
-    if (!aIsFav && bIsFav) return 1
-
-    return a.number - b.number
-  })
+  return [...props.lessons].sort((a, b) => a.number - b.number)
 })
 
 function isNextLesson(number) {

--- a/src/components/LearningPath.vue
+++ b/src/components/LearningPath.vue
@@ -95,29 +95,17 @@ const completedRatio = computed(() => {
 
 const sortedLessons = computed(() => {
   const lessons = [...props.lessons]
-  const nextNum = props.nextLessonNumber
   const favSet = new Set(props.favorites)
 
   return lessons.sort((a, b) => {
-    const aIsNext = a.number === nextNum
-    const bIsNext = b.number === nextNum
-    if (aIsNext && !bIsNext) return -1
-    if (!aIsNext && bIsNext) return 1
-
     const aIsFav = favSet.has(a.number)
     const bIsFav = favSet.has(b.number)
-    const aCompleted = props.getStatus(a.number) === 'completed'
-    const bCompleted = props.getStatus(b.number) === 'completed'
-
-    if (aIsFav && !aCompleted && (!bIsFav || bCompleted)) return -1
-    if (bIsFav && !bCompleted && (!aIsFav || aCompleted)) return 1
-
-    if (aCompleted && !bCompleted) return 1
-    if (!aCompleted && bCompleted) return -1
 
     if (aIsFav && bIsFav) {
       return props.favorites.indexOf(a.number) - props.favorites.indexOf(b.number)
     }
+    if (aIsFav && !bIsFav) return -1
+    if (!aIsFav && bIsFav) return 1
 
     return a.number - b.number
   })

--- a/src/views/WorkshopOverview.vue
+++ b/src/views/WorkshopOverview.vue
@@ -224,20 +224,7 @@ function dismissNotice() {
 
 const workshops = computed(() => {
   if (!learning.value) return []
-  const list = Object.keys(availableContent.value[learning.value] || {})
-  return list.sort((a, b) => {
-    const aKey = `${learning.value}:${a}`
-    const bKey = `${learning.value}:${b}`
-    const aActive = activeWorkshops.value.includes(aKey) ? 0 : 1
-    const bActive = activeWorkshops.value.includes(bKey) ? 0 : 1
-    if (aActive !== bActive) return aActive - bActive
-    const aFav = favorites.value.includes(a) ? 0 : 1
-    const bFav = favorites.value.includes(b) ? 0 : 1
-    if (aFav !== bFav) return aFav - bFav
-    const aImg = getWorkshopImage(a) ? 0 : 1
-    const bImg = getWorkshopImage(b) ? 0 : 1
-    return aImg - bImg
-  })
+  return Object.keys(availableContent.value[learning.value] || {})
 })
 
 function getWorkshopLabels(workshop) {

--- a/src/views/WorkshopOverview.vue
+++ b/src/views/WorkshopOverview.vue
@@ -169,7 +169,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useLessons } from '../composables/useLessons'
 import { useOffline } from '../composables/useOffline'
@@ -222,9 +222,26 @@ function dismissNotice() {
   router.replace({ name: 'workshop-overview', params: { learning: learning.value } })
 }
 
+const workshopOrder = ref([])
+
+watch(
+  () => Object.keys(availableContent.value[learning.value] || {}),
+  (keys) => {
+    // Append new workshops without changing the order of existing ones
+    for (const key of keys) {
+      if (!workshopOrder.value.includes(key)) {
+        workshopOrder.value.push(key)
+      }
+    }
+    // Remove workshops that no longer exist
+    workshopOrder.value = workshopOrder.value.filter(k => keys.includes(k))
+  },
+  { immediate: true }
+)
+
 const workshops = computed(() => {
   if (!learning.value) return []
-  return Object.keys(availableContent.value[learning.value] || {})
+  return workshopOrder.value
 })
 
 function getWorkshopLabels(workshop) {


### PR DESCRIPTION
Closes #248.

## Problem

Clicking the favorite star (★) or starting a workshop caused it to jump to a different position in the list. The `workshops` computed property sorted by active → favorite → has-image on every render, so any state change triggered a re-sort.

## Fix

Remove the dynamic sort. The list now keeps the original source order from `availableContent`.

## Test

1. http://localhost:5173/#/deutsch
2. Merke dir die Position eines Workshops (z.B. Portugiesisch ist 2.)
3. Klick auf ★ Favorit → Workshop bleibt an Position 2
4. Workshop öffnen, eine Lektion machen → zurück zur Übersicht → Workshop bleibt an Position 2