### PR TITLE
fix: resume playback from clicked example + cleanup always-continuous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ### Fixes
 
+#### Resume von Example-Klick spielt jetzt die ganze Lektion weiter
+
+Play → Pause → Klick auf ein Example → Play: spielte vorher nur das eine Example ab und stoppte. Jetzt setzt die Wiedergabe ab dem geklickten Example fort und läuft die restliche Lektion durch.
+
+**Ursache:** `jumpToExample` rief bei Pause `playSingleItem` auf, was den `onended`-Handler des Blessed Players mit einem No-Op überschrieb und `planIdx` nicht repositionierte. Beim Resume versuchte `play()` den Blessed Player fortzusetzen, dessen Audio aber bereits beendet war.
+
+**Fix:** Neuer Paused-Branch in `jumpToExample` — repositioniert `planIdx` im Playback-Plan und setzt ein `_planRepositioned`-Flag. `play()` erkennt das Flag und startet `advancePlan()` statt den stale Blessed Player zu resumen.
+
+### Cleanup
+
+#### Always-Continuous Cleanup (Follow-up zu #250)
+
+- Entfernt `toggleContinuousPlay` aus `useLessonAudioSync.js` (dead code seit Play immer continuous ist)
+- Entfernt `continuousPlayActive` i18n-Strings (DE, EN, AR, FA) — referenzierten Double-Click der nicht mehr existiert
+- Entfernt veraltete Double-Click-Kommentare aus `App.vue` und `useAudio.js`
+- 2 Tests entfernt die `toggleContinuousPlay` testeten
+
 #### Workshops und Lektionen springen nicht mehr beim Favorisieren oder Abhaken (#248)
 - Workshop-Liste behält die ursprüngliche Reihenfolge aus der Quelle
 - Lektionen bleiben an ihrer Stelle wenn sie als erledigt markiert oder favorisiert werden

--- a/src/App.vue
+++ b/src/App.vue
@@ -664,13 +664,6 @@ function togglePlayPause() {
   }
 }
 
-// Single vs. double click for the desktop play button. The actual next-lesson
-// resolver is provided by LessonDetail (which knows the lesson list) via the
-// same enableContinuousMode path; here we just toggle continuous mode on/off.
-// If there is no active provider (e.g. lessons not loaded yet), the first
-// double-click is a no-op — LessonDetail re-registers the provider on mount.
-// No double-click handler — play is always continuous.
-
 // Router-view key strategy. See the comment on the `<component :key>`
 // binding in the template above.
 function viewKey(route) {

--- a/src/composables/useAudio.js
+++ b/src/composables/useAudio.js
@@ -83,6 +83,11 @@ function getSilenceUrl(durationMs) {
 //   - stop() / cleanup() (clear)
 const playbackPlan = ref([])
 let planIdx = -1
+// Set by jumpToExample when the user clicks an example while paused.
+// Tells play() to advance from the repositioned planIdx instead of
+// resuming the blessed player (whose src/onended are stale after
+// playSingleItem).
+let _planRepositioned = false
 
 /**
  * Build the playback plan from a reading queue. The result interleaves
@@ -775,7 +780,12 @@ async function play(settings) {
     planIdx,
   })
 
-  if (wasResuming) {
+  if (wasResuming && _planRepositioned) {
+    // The user clicked an example while paused — planIdx was repositioned.
+    // Advance from there instead of resuming the stale blessed player.
+    _planRepositioned = false
+    advancePlan()
+  } else if (wasResuming) {
     // Resume: just call play() on the blessed player (same src, same position)
     try {
       await blessedPlayer.value.play()
@@ -829,6 +839,7 @@ function stop() {
   isPaused.value = false
   currentItemIndex.value = -1
   planIdx = -1
+  _planRepositioned = false
 
   if (blessedPlayer.value) {
     try {
@@ -947,6 +958,18 @@ function jumpToExample(sectionIdx, exampleIdx, settings) {
         blessedPlayer.value?.pause()
         advancePlan()
       }
+    } else if (isPaused.value && playbackPlan.value.length > 0) {
+      // Paused: reposition the plan so the next play() continues from here.
+      // Play the clicked example immediately for feedback.
+      const planTarget = playbackPlan.value.findIndex(
+        e => !e.isSilence && e.queueIndex === index
+      )
+      if (planTarget >= 0) {
+        planIdx = planTarget
+        _planRepositioned = true
+      }
+      currentItemIndex.value = index
+      playSingleItem(index, settings)
     } else {
       currentItemIndex.value = index
       playSingleItem(index, settings)
@@ -1100,7 +1123,7 @@ function sumPreloadedPlaytime() {
 
 /**
  * Preload every remaining lesson in the workshop, up to a 1-hour playtime
- * budget. Called from inside the user's double-click gesture handler so all
+ * budget. Called when continuous mode is enabled so all
  * Audio elements exist before the chain advances — this is what keeps iOS
  * happy across continuous-mode transitions (fix E for #240).
  */

--- a/src/composables/useLessonAudioSync.js
+++ b/src/composables/useLessonAudioSync.js
@@ -115,26 +115,6 @@ export function useLessonAudioSync() {
     return true
   }
 
-  /**
-   * Toggles continuous play mode. After fix C for #240, the composable has
-   * its own built-in resolver based on `setWorkshopLessons`, so the caller
-   * no longer needs to pass a closure — we just flip the flag.
-   *
-   * `nextLessonProvider` is still accepted for backwards compatibility
-   * but callers that use setWorkshopLessons should pass nothing.
-   */
-  function toggleContinuousPlay({ nextLessonProvider, audioSettings } = {}) {
-    if (continuousMode.value) {
-      disableContinuousMode()
-      return false
-    }
-    enableContinuousMode(nextLessonProvider)
-    if (!isPlaying.value) {
-      play(audioSettings)
-    }
-    return true
-  }
-
   return {
     // Reactive state forwarded from useAudio so the view doesn't import both
     isLoadingAudio,
@@ -160,6 +140,5 @@ export function useLessonAudioSync() {
     onProgressChanged,
     onLessonMount,
     onLessonUnmount,
-    toggleContinuousPlay,
   }
 }

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -8,7 +8,6 @@
     "pauseAudio": "إيقاف الصوت",
     "playAudio": "تشغيل الصوت",
     "loadingAudio": "جاري تحميل الصوت...",
-    "continuousPlayActive": "تشغيل متواصل (نقر مزدوج للإيقاف)",
     "assessmentResults": "نتائج التقييم",
     "coach": "المدرب",
     "learningItems": "عناصر التعلم",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -8,7 +8,6 @@
     "pauseAudio": "Audio pausieren",
     "playAudio": "Audio abspielen",
     "loadingAudio": "Audio wird geladen...",
-    "continuousPlayActive": "Endlos-Wiedergabe (Doppelklick zum Stoppen)",
     "assessmentResults": "Ergebnisse",
     "coach": "Coach",
     "learningItems": "Lernelemente",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -8,7 +8,6 @@
     "pauseAudio": "Pause audio",
     "playAudio": "Play audio",
     "loadingAudio": "Loading audio...",
-    "continuousPlayActive": "Continuous play (double click to stop)",
     "assessmentResults": "Assessment Results",
     "coach": "Coach",
     "learningItems": "Learning items",

--- a/src/i18n/fa.json
+++ b/src/i18n/fa.json
@@ -8,7 +8,6 @@
     "pauseAudio": "توقف صدا",
     "playAudio": "پخش صدا",
     "loadingAudio": "در حال بارگذاری صدا...",
-    "continuousPlayActive": "پخش پیوسته (برای توقف دو بار کلیک کنید)",
     "assessmentResults": "نتایج ارزیابی",
     "coach": "مربی",
     "learningItems": "موارد یادگیری",

--- a/tests/lesson-audio-sync.test.js
+++ b/tests/lesson-audio-sync.test.js
@@ -284,35 +284,4 @@ describe('useLessonAudioSync', () => {
     })
   })
 
-  // --- toggleContinuousPlay ---
-
-  describe('toggleContinuousPlay', () => {
-    it('enables continuous mode and starts playback on first call', async () => {
-      await sync.onLessonMount({
-        lesson: lesson1, learning: 'de', workshop: 'pt', audioSettings: settings,
-      })
-
-      const enabled = sync.toggleContinuousPlay({
-        nextLessonProvider: async () => null,
-        audioSettings: settings,
-      })
-      expect(enabled).toBe(true)
-      expect(audio.continuousMode.value).toBe(true)
-      expect(audio.isPlaying.value).toBe(true)
-    })
-
-    it('disables continuous mode on second call', async () => {
-      await sync.onLessonMount({
-        lesson: lesson1, learning: 'de', workshop: 'pt', audioSettings: settings,
-      })
-      sync.toggleContinuousPlay({
-        nextLessonProvider: async () => null, audioSettings: settings,
-      })
-      const stillOn = sync.toggleContinuousPlay({
-        nextLessonProvider: async () => null, audioSettings: settings,
-      })
-      expect(stillOn).toBe(false)
-      expect(audio.continuousMode.value).toBe(false)
-    })
-  })
 })


### PR DESCRIPTION
## Summary

- **Bug fix:** Play → Pause → click example → Play now continues from that example through the rest of the lesson. Previously only the single clicked example would play and then stop.
- **Cleanup (follow-up to #250):** Remove dead `toggleContinuousPlay`, unused `continuousPlayActive` i18n strings, stale double-click comments, and 2 obsolete tests.

## Bug Details

**Root cause:** `jumpToExample` called `playSingleItem` during pause, which replaced the blessed player's `onended` handler with a no-op and didn't reposition `planIdx`. On resume, `play()` tried to continue the stale blessed player whose audio had already ended.

**Fix:** New paused branch in `jumpToExample` repositions `planIdx` in the playback plan and sets a `_planRepositioned` flag. `play()` detects the flag and calls `advancePlan()` instead of resuming the stale blessed player.

## Test plan

- [x] 233 unit tests passing (2 removed for dead `toggleContinuousPlay`)
- [ ] Manual: Play → Pause → click an example → hear it play → click Play → verify chain continues from that example onward
- [ ] Manual: Normal pause/resume (without clicking an example) still works
- [ ] Manual: Click example while stopped (not paused) → plays single item only