### PR TITLE
fix: restore workshop and lesson sorting (follow-up to #249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ Play → Pause → Klick auf ein Example → Play: spielte vorher nur das eine E
 - Entfernt veraltete Double-Click-Kommentare aus `App.vue` und `useAudio.js`
 - 2 Tests entfernt die `toggleContinuousPlay` testeten
 
-#### Workshops und Lektionen springen nicht mehr beim Favorisieren oder Abhaken (#248)
-- Workshop-Liste behält die ursprüngliche Reihenfolge aus der Quelle
+#### Workshop- und Lektions-Sortierung korrigiert (Follow-up zu #249)
+- Workshops: Sortierung nach aktiv → favorit → hat Bild wiederhergestellt (war fälschlich entfernt)
+- Lektionen: Favoriten zuerst (nach Nummer), dann Rest (nach Nummer). Erledigt-Status hat keinen Einfluss auf Sortierung
 - Lektionen bleiben an ihrer Stelle wenn sie als erledigt markiert oder favorisiert werden
 - Kein automatisches Umsortieren nach aktiv/favorit/erledigt mehr
 

--- a/specs/navigation-and-ux.md
+++ b/specs/navigation-and-ux.md
@@ -31,7 +31,11 @@ The top navigation bar adapts to the current page:
 
 ## Workshop Favorites and Sorting
 
-Learners can mark workshops and lessons as favorites. Favorites are visually highlighted but stay in their original position — the list never reorders automatically. Completed lessons also stay in place.
+Learners can mark workshops and lessons as favorites.
+
+**Workshop sort order:** active → favorite → has image → source order. Toggling favorite or active re-sorts the list.
+
+**Lesson sort order:** favorites first (by lesson number), then all others (by lesson number). Completed/done status has no effect on sort order.
 
 ## Dark Mode
 

--- a/src/components/LearningPath.vue
+++ b/src/components/LearningPath.vue
@@ -94,7 +94,13 @@ const completedRatio = computed(() => {
 })
 
 const sortedLessons = computed(() => {
-  return [...props.lessons].sort((a, b) => a.number - b.number)
+  const favSet = new Set(props.favorites)
+  return [...props.lessons].sort((a, b) => {
+    const aFav = favSet.has(a.number) ? 0 : 1
+    const bFav = favSet.has(b.number) ? 0 : 1
+    if (aFav !== bFav) return aFav - bFav
+    return a.number - b.number
+  })
 })
 
 function isNextLesson(number) {

--- a/src/views/WorkshopOverview.vue
+++ b/src/views/WorkshopOverview.vue
@@ -169,7 +169,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useLessons } from '../composables/useLessons'
 import { useOffline } from '../composables/useOffline'
@@ -222,26 +222,22 @@ function dismissNotice() {
   router.replace({ name: 'workshop-overview', params: { learning: learning.value } })
 }
 
-const workshopOrder = ref([])
-
-watch(
-  () => Object.keys(availableContent.value[learning.value] || {}),
-  (keys) => {
-    // Append new workshops without changing the order of existing ones
-    for (const key of keys) {
-      if (!workshopOrder.value.includes(key)) {
-        workshopOrder.value.push(key)
-      }
-    }
-    // Remove workshops that no longer exist
-    workshopOrder.value = workshopOrder.value.filter(k => keys.includes(k))
-  },
-  { immediate: true }
-)
-
 const workshops = computed(() => {
   if (!learning.value) return []
-  return workshopOrder.value
+  const list = Object.keys(availableContent.value[learning.value] || {})
+  return list.sort((a, b) => {
+    const aKey = `${learning.value}:${a}`
+    const bKey = `${learning.value}:${b}`
+    const aActive = activeWorkshops.value.includes(aKey) ? 0 : 1
+    const bActive = activeWorkshops.value.includes(bKey) ? 0 : 1
+    if (aActive !== bActive) return aActive - bActive
+    const aFav = favorites.value.includes(a) ? 0 : 1
+    const bFav = favorites.value.includes(b) ? 0 : 1
+    if (aFav !== bFav) return aFav - bFav
+    const aImg = getWorkshopImage(a) ? 0 : 1
+    const bImg = getWorkshopImage(b) ? 0 : 1
+    return aImg - bImg
+  })
 })
 
 function getWorkshopLabels(workshop) {


### PR DESCRIPTION
## Summary

#249 removed all sorting to fix the jumping issue (#248), but went too far — the intended sort order should be preserved. This PR restores it with the correct rules:

**Workshops:** active → favorite → has image → source order
**Lessons:** favorites first (by number), then all others (by number)

**Key change from original:** completed/done status has **no effect** on sort order. That was the actual cause of the jumping in #248 — marking a lesson as done moved it to the bottom.

## Changes

- `WorkshopOverview.vue`: Restore active → favorite → has-image sort
- `LearningPath.vue`: Sort favorites first by number, then rest by number (no completed-based sorting)
- `specs/navigation-and-ux.md`: Document the correct sort rules
- `CHANGELOG.md`: Updated entry

## Test plan

- [x] Favorite a workshop → moves to top (after active ones)
- [ ] Mark a workshop as active → moves to top
- [ ] Favorite a lesson → moves to top of list (within favorites, sorted by number)
- [x] Mark a lesson as done → stays in place, does NOT jump