### PR TITLE
fix: left/right tap skips example within section in Story Mode (#254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-04-13
+
+### Fixes
+
+#### Story Mode: Links/Rechts-Tippen springt zum nächsten Absatz (#254)
+
+Tippen links oder rechts (egal wo auf dem Bildschirm) springt jetzt zum nächsten bzw. vorherigen Absatz innerhalb der aktuellen Section — ohne die Section zu wechseln. Audio spielt sofort den neuen Absatz ab. Die Section wechselt erst automatisch nach dem letzten Absatz.
+
 ## 2026-04-12
 
 ### Fixes

--- a/src/views/StoryView.vue
+++ b/src/views/StoryView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fixed inset-0 z-[100] flex flex-col story-bg" style="height: 100lvh">
+  <div class="fixed inset-0 z-[100] flex flex-col story-bg" style="height: 100lvh" @click="handleTap($event)">
     <!-- Exit button (top-left, press-and-hold 2s) -->
     <button
       class="absolute top-4 left-4 z-[110] w-14 h-14 rounded-full bg-black/50 text-white flex items-center justify-center transition-all"
@@ -7,6 +7,7 @@
       @pointerdown="startExit"
       @pointerup="cancelExit"
       @pointerleave="cancelExit"
+      @click.stop
       title="Hold to exit"
       aria-label="Hold to exit">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -56,12 +57,12 @@
       <div class="text-white text-2xl font-bold text-center">Story complete</div>
       <div class="flex flex-col gap-3 w-full max-w-xs">
         <button
-          @click="restartFromBeginning"
+          @click.stop="restartFromBeginning"
           class="w-full px-6 py-3 rounded-xl bg-white/10 text-white text-lg font-medium hover:bg-white/20 transition">
           Restart from Lesson 1
         </button>
         <button
-          @click="goToOverview"
+          @click.stop="goToOverview"
           class="w-full px-6 py-3 rounded-xl bg-white/5 text-white/60 text-sm hover:bg-white/10 transition">
           Back to overview
         </button>
@@ -70,7 +71,7 @@
 
     <!-- Story content -->
     <template v-else>
-      <div class="flex-1 relative overflow-hidden" @click="handleTap($event)">
+      <div class="flex-1 relative overflow-hidden">
 
         <!-- Atmospheric background layer -->
         <div class="absolute inset-0 pointer-events-none z-0" :class="`scene-bg scene-${sceneType}`">

--- a/src/views/StoryView.vue
+++ b/src/views/StoryView.vue
@@ -854,34 +854,18 @@ function handleTap(e) {
   const clickX = e.clientX - rect.left
   const isLeftSide = clickX < rect.width / 2
 
-  // In assessment states, only allow going back via left tap
-  if (state.value === 'choosing' || state.value === 'input') {
-    if (isLeftSide && currentExampleIndex.value > 0) {
-      currentExampleIndex.value--
-      showCurrentExample()
-    }
-    return
-  }
+  // In assessment states, tapping does nothing (use answer buttons)
+  if (state.value === 'choosing' || state.value === 'input') return
 
   if (state.value !== 'narrating') return
 
   clearAutoAdvance()
 
+  // Left/right tap always navigates sections — pages use the zurück/weiter buttons
   if (isLeftSide) {
-    // Go back: previous page, or previous example if on first page
-    if (currentPage.value > 0) {
-      prevPage()
-    } else if (currentExampleIndex.value > 0) {
-      currentExampleIndex.value--
-      showCurrentExample()
-    }
+    prevSection()
   } else {
-    // Advance: next page first, then advance to next section/assessment
-    if (currentPage.value < totalPages.value - 1) {
-      nextPage()
-    } else {
-      advanceExample()
-    }
+    advanceSection()
   }
 }
 
@@ -1170,6 +1154,20 @@ async function advanceSection() {
   } else {
     advanceLesson()
   }
+}
+
+async function prevSection() {
+  if (!currentLesson.value?.sections) return
+  const prevSectionIdx = currentSectionIndex.value - 1
+  if (prevSectionIdx >= 0) {
+    currentSectionIndex.value = prevSectionIdx
+    currentExampleIndex.value = 0
+    currentPage.value = 0
+    imageLoaded.value = false
+    await playSectionIntro()
+    showCurrentExample()
+  }
+  // already on first section — do nothing
 }
 
 function advanceLesson() {

--- a/src/views/StoryView.vue
+++ b/src/views/StoryView.vue
@@ -862,11 +862,23 @@ function handleTap(e) {
 
   clearAutoAdvance()
 
-  // Left/right tap always navigates sections — pages use the zurück/weiter buttons
   if (isLeftSide) {
-    prevSection()
+    // Go back one example; update page to follow
+    if (currentExampleIndex.value > 0) {
+      currentExampleIndex.value--
+      currentPage.value = Math.floor(currentExampleIndex.value / paragraphsPerPage.value)
+      showCurrentExample()
+    }
   } else {
-    advanceSection()
+    // Advance one example; update page to follow
+    const nextIdx = currentExampleIndex.value + 1
+    const section = currentLesson.value?.sections?.[currentSectionIndex.value]
+    const examplesInSection = section?.examples?.length || 0
+    if (nextIdx < examplesInSection) {
+      currentExampleIndex.value = nextIdx
+      currentPage.value = Math.floor(currentExampleIndex.value / paragraphsPerPage.value)
+      showCurrentExample()
+    }
   }
 }
 


### PR DESCRIPTION
## Was wurde geändert

Links/Rechts-Tippen (egal wo auf dem Bildschirm) springt jetzt zum **nächsten/vorherigen Absatz** innerhalb der aktuellen Section — ohne die Section zu wechseln.

## Verhalten vorher vs. nachher

```
Vorher: Rechts tippen → nächste SECTION (zu dramatisch, gesamter Inhalt wechselt)
Jetzt:  Rechts tippen → nächster ABSATZ innerhalb der gleichen Section

Vorher: Links tippen → vorherige SECTION
Jetzt:  Links tippen → vorheriger ABSATZ innerhalb der gleichen Section
```

Section wechselt nur automatisch nach dem letzten Absatz.

## Details

- Click-Handler liegt auf dem **gesamten Bildschirm** (`fixed inset-0`) — überall klickbar
- `currentExampleIndex` wird um 1 vor/zurück bewegt
- `currentPage` aktualisiert sich mit, damit der Absatz immer sichtbar ist
- Audio spielt den neuen Absatz sofort ab
- `zurück / weiter` Buttons am unteren Rand bleiben für Seiten-Navigation

## Test

1. http://open-learn.app/#/deutsch/milas-abenteuer/story/1 (nach Merge)
2. Rechts tippen → nächster Satz wird gelesen, Section bleibt gleich
3. Links tippen → vorheriger Satz, Section bleibt gleich
4. Am letzten Absatz angelangt → Story läuft automatisch weiter zur nächsten Section