### PR TITLE
chore: remove unused prevSection() from StoryView (follow-up to #255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - Beschrieb noch den Double-Click-Toggle, der in #250 entfernt wurde
 - Text beschreibt jetzt das tatsächliche Verhalten: Play = immer continuous
 
+### Cleanup
+
+#### Remove unused `prevSection()` from Story Mode (Follow-up zu #255)
+- Tote Funktion entfernt — nicht referenziert, da Tap-Navigation nur innerhalb der Section springt
+
 ### Fixes
 
 #### Story Mode: Links/Rechts-Tippen springt zum nächsten Absatz (#254)

--- a/src/views/StoryView.vue
+++ b/src/views/StoryView.vue
@@ -1169,20 +1169,6 @@ async function advanceSection() {
   }
 }
 
-async function prevSection() {
-  if (!currentLesson.value?.sections) return
-  const prevSectionIdx = currentSectionIndex.value - 1
-  if (prevSectionIdx >= 0) {
-    currentSectionIndex.value = prevSectionIdx
-    currentExampleIndex.value = 0
-    currentPage.value = 0
-    imageLoaded.value = false
-    await playSectionIntro()
-    showCurrentExample()
-  }
-  // already on first section — do nothing
-}
-
 function advanceLesson() {
   const nextLesson = lessons.value.find(l => l.number === lessonNumber.value + 1)
   if (nextLesson) {


### PR DESCRIPTION
## Summary

- Remove unused `prevSection()` function in `StoryView.vue` introduced by #255.
- The tap-navigation change in #255 intentionally moved left/right taps to navigate **by example within the section** — there is no caller for `prevSection()` anywhere in the codebase (verified via grep).
- No behavioural change; pure dead-code removal.

## Test plan

- [x] `npx vitest --run` — 233/233 passing
- [ ] Manual smoke: open Story Mode, left-tap at first example of first section → stays put (as #255 intends)