### PR TITLE
docs: features.md Continuous Play → always-continuous (post-#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2026-04-13
 
+### Docs & CI
+
+#### `docs/features.md`: Continuous Play Mode auf Always-Continuous aktualisiert
+- Beschrieb noch den Double-Click-Toggle, der in #250 entfernt wurde
+- Text beschreibt jetzt das tatsächliche Verhalten: Play = immer continuous
+
 ### Fixes
 
 #### Story Mode: Links/Rechts-Tippen springt zum nächsten Absatz (#254)

--- a/docs/features.md
+++ b/docs/features.md
@@ -137,14 +137,12 @@ Pre-generated MP3 files for questions and answers, played in sequence.
 - Click question text to toggle answer, click example card to play audio
 
 ### Continuous Play Mode
-Double-click the play button to auto-advance through the entire workshop, including from the lock screen.
+Pressing play auto-advances through the entire workshop — title → sections → examples → next lesson — including from the lock screen. There is no toggle; continuous is the only mode.
 
-- Single click: play/pause current lesson (unchanged)
-- Double click: toggle continuous play — lessons advance automatically when finished
-- Visual indicator: repeat badge + yellow ring on the play button
+- Single click: play/pause (always continuous, no separate single-lesson mode)
 - Next lesson audio is preloaded in the background for seamless transitions
 - Works offline and online; non-downloaded workshops load the next lesson in the background
-- A second double click turns continuous play off without stopping playback
+- History: a double-click toggle existed pre-#250 but was removed to simplify the mental model ("press play, hear the workshop")
 
 ### Lock Screen Controls
 Media Session API integration for mobile lock screen play/pause/skip controls.


### PR DESCRIPTION
## Summary

- `docs/features.md` still described the double-click continuous-play toggle that #250 removed.
- #251 was merged on 2026-04-12 documenting features, but was stale on merge — parallel work in #250 removed the very feature #251 documented.
- This PR rewrites the section to describe the current behaviour: play = always continuous, no toggle.

## Test plan

- [x] No code changes, docs only.
- [ ] Quick read of the new section for accuracy.