### PR TITLE
fix: tap during story intro skips to first example (#259)

### DIFF
--- a/src/views/StoryView.vue
+++ b/src/views/StoryView.vue
@@ -855,6 +855,15 @@ function handleTap(e) {
   const clickX = e.clientX - rect.left
   const isLeftSide = clickX < rect.width / 2
 
+  // Tap during intro → skip intro, start first example immediately
+  if (showingIntro.value) {
+    showingIntro.value = false
+    stopSpeaking()
+    clearAutoAdvance()
+    showCurrentExample()
+    return
+  }
+
   // In assessment states, tapping does nothing (use answer buttons)
   if (state.value === 'choosing' || state.value === 'input') return
 


### PR DESCRIPTION
## Problem

Auf dem Handy: Während der Intro-Screen (Lektionstitel z.B. „Der geheimnisvolle Wald") angezeigt wird, passiert beim Tippen nichts — die Seite bleibt stehen aber Audio läuft weiter.

## Fix

In `handleTap()`: wenn `showingIntro.value === true` → Audio sofort stoppen, Intro beenden, direkt zum ersten Example springen.

## Test

http://localhost:5173/#/deutsch/milas-abenteuer/story/1

1. Story starten → Intro-Screen mit Lektionstitel erscheint
2. Irgendwo tippen → Intro verschwindet sofort, erstes Example startet
3. Auf Handy testen (iOS Safari / Chrome)

Closes #259