### PR TITLE
fix: tour ?tour=1 param not working in hash-based routing

### DIFF
--- a/src/composables/useTour.js
+++ b/src/composables/useTour.js
@@ -68,7 +68,9 @@ async function showTour(stepDefs, doneKey, force = false, anchorSelector = null)
 }
 
 // ?tour=1 in URL forces tour every time (for testing)
-const urlForce = new URLSearchParams(window.location.search).get('tour') === '1'
+// Hash-based routing: query params are in the hash, not window.location.search
+const hashQuery = new URLSearchParams(window.location.hash.split('?')[1] || '')
+const urlForce = hashQuery.get('tour') === '1'
 
 export function useTour() {
   function startWorkshopOverviewTour(tr, force = false) {


### PR DESCRIPTION
## Bug

`?tour=1` in der URL erzwang die Tour nicht — sie erschien nie beim Testen.

## Ursache

```js
// Vorher — liest window.location.search
// Bei Hash-Routing ist search immer leer!
new URLSearchParams(window.location.search).get('tour')

// Nachher — liest aus dem Hash
const hashQuery = new URLSearchParams(window.location.hash.split('?')[1] || '')
hashQuery.get('tour') === '1'
```

Die App nutzt Hash-Routing (`#/deutsch?tour=1`). Der Query-Parameter steckt im Hash, nicht in `window.location.search`.

## Test

http://localhost:5173/#/deutsch?tour=1 → Tour erscheint sofort