### PR TITLE
feat: prefetch lesson data on workshop card hover (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-04-29
+
+### Features
+
+#### Prefetch von Lessons beim Hover über Workshop-Karten (#124)
+
+Wenn der Maus-Cursor über eine Workshop-Karte schwebt, lädt die App im Hintergrund schon die Lessons. Beim Klick navigiert die App dadurch ohne sichtbare Wartezeit.
+
+- **Shimmer im Akzent-Balken** während des Ladens — animierter Glanz von links nach rechts
+- **Glow-Pulse am Karten-Rand** sobald die Daten im Cache sind — Karte signalisiert "klick mich"
+- **Touch-Geräte ausgeschlossen** — `pointerType === 'touch'` wird übersprungen, kein Prefetch beim Scrollen
+- **Daten-Schonmodus** — `Save-Data` und `slow-2g`/`2g` Verbindungen bekommen kein Prefetch
+- **`prefers-reduced-motion`** — Shimmer und Glow werden für User mit reduzierten Bewegungen abgeschaltet
+
 ## 2026-04-14
 
 ### Features

--- a/specs/workshop-card-prefetch.md
+++ b/specs/workshop-card-prefetch.md
@@ -1,0 +1,66 @@
+# Workshop Card Prefetch — Hover Beschleunigt den Klick
+
+**Issue: [#124](https://github.com/openlearnapp/openlearnapp.github.io/issues/124)**
+
+## Zweck
+
+Heute zeigt die App nach dem Klick auf eine Workshop-Karte einen Ladezustand, bis alle Lektionen geladen sind. Bei langsamen Netzen sind das mehrere hundert Millisekunden bis Sekunden gefühlte Wartezeit.
+
+Die Hover-Bewegung der Maus dauert vom Beginn des Hovers bis zum Klick typischerweise 200–500ms. In diesem Fenster lassen sich die Daten **vorab im Hintergrund laden**, sodass der Klick anschließend ohne Verzögerung navigiert.
+
+## Aktueller Zustand
+
+- `WorkshopOverview.vue` rendert ein Grid aus Workshop-Karten.
+- `@click="openWorkshop(ws)"` navigiert zur `LessonsOverview`-Route.
+- Erst nach der Navigation startet `loadAllLessonsForWorkshop()` — das Lesson-Grid bleibt leer bis die Daten da sind.
+- `loadAllLessonsForWorkshop()` ist bereits memoized in `useLessons.js` (siehe `lessonsCache`). Mehrfache Aufrufe für dasselbe Workshop dedupen.
+
+## Neues Verhalten
+
+### Prefetch beim Hover
+
+Sobald der Maus-Cursor über eine Workshop-Karte schwebt, startet im Hintergrund das Laden der Lessons. Die UI ist nicht blockiert — der User kann frei weiterklicken oder weghovern.
+
+- Auslöser: `@pointerenter` auf der Karte
+- Aktion: `loadAllLessonsForWorkshop(learning, ws)` (non-blocking)
+- Cache: bereits geladen → kein zweiter Request
+- Fehler: still verschluckt (`.catch(() => {})`) — Prefetch ist Best-Effort
+
+### Visuelles Feedback (Wow-Effekt)
+
+Drei Karten-Zustände, sichtbar gemacht durch dezente Animationen:
+
+| Status | Auslöser | Visuell |
+|---|---|---|
+| `idle` | Default | Standard-Karte |
+| `loading` | Pointer ist auf Karte, Daten werden geladen | **Shimmer** im Akzent-Balken oben (animierter Glanz von links nach rechts) |
+| `ready` | Daten sind im Cache | **Glow-Pulse** am Karten-Rand (Primary-Farbe), 1× kurz aufleuchtend |
+
+Der Übergang `loading → ready` ist die Belohnung: die Karte signalisiert "ich bin bereit, klick mich". Bei warmem Cache (zweites Hover) ist die Karte sofort `ready`, kein Shimmer.
+
+### Mobile-Verhalten
+
+- Touch-Geräte feuern `pointerenter` auch beim Scrollen — das wäre Datenverschwendung.
+- Lösung: Prefetch nur wenn `event.pointerType !== 'touch'` (also nur Maus/Pen).
+- Mobile-User profitieren beim Klick (durch Cache nach erstem Aufruf), zahlen aber nicht für Hover-Phantome.
+
+### Daten-Schonmodus
+
+Respektiere `navigator.connection`:
+- `saveData === true` → kein Prefetch
+- `effectiveType` ∈ {`slow-2g`, `2g`} → kein Prefetch
+
+User mit aktivem Datensparen oder schwachem Netz bekommen den klassischen Klick-Pfad ohne Hintergrundlast.
+
+## Erwarteter Effekt
+
+- Desktop-Klick fühlt sich **instant** an, wenn die Hover-Phase ≥ 200ms dauert.
+- Bereits geladene Workshops (z.B. nach Rückkehr von einer Lektion) erscheinen sofort als `ready`.
+- Keine zusätzlichen Requests bei warmem Cache.
+- Keine Mehrlast für Mobile / Daten-Sparmodus.
+
+## Was nicht im Scope ist
+
+- Long-Press auf Mobile als Prefetch-Trigger (zu komplex, geringer Nutzen).
+- Cancel laufender Fetches beim Weghovern (Browser dedupliziert ohnehin via Memoization-Cache).
+- Prefetch von Bildern / Audio (Issue beschränkt sich auf Lesson-Metadata).

--- a/src/style.css
+++ b/src/style.css
@@ -61,3 +61,36 @@
   }
 }
 
+/* Workshop card prefetch feedback (issue #124) */
+@keyframes card-prefetch-shimmer {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+.card-prefetch-shimmer {
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.65) 50%,
+    transparent 100%
+  );
+  animation: card-prefetch-shimmer 1.1s ease-in-out infinite;
+  pointer-events: none;
+}
+
+@keyframes card-prefetch-glow {
+  0%   { box-shadow: 0 0 0 0 hsl(var(--primary) / 0); }
+  35%  { box-shadow: 0 0 0 6px hsl(var(--primary) / 0.35); }
+  100% { box-shadow: 0 0 0 0 hsl(var(--primary) / 0); }
+}
+
+.card-prefetch-ready {
+  animation: card-prefetch-glow 0.9s ease-out 1;
+  border-color: hsl(var(--primary) / 0.6) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-prefetch-shimmer { animation: none; opacity: 0.4; }
+  .card-prefetch-ready { animation: none; }
+}
+

--- a/src/views/WorkshopOverview.vue
+++ b/src/views/WorkshopOverview.vue
@@ -42,11 +42,19 @@
           :id="wsIndex === 0 ? 'tour-workshop-card' : undefined"
           :key="ws"
           @click="openWorkshop(ws)"
-          class="group cursor-pointer transition-all duration-200 hover:shadow-lg hover:-translate-y-0.5 hover:border-primary/50 overflow-hidden"
+          @pointerenter="handlePointerEnter($event, ws)"
+          class="group cursor-pointer relative transition-all duration-200 hover:shadow-lg hover:-translate-y-0.5 hover:border-primary/50 overflow-hidden"
+          :class="{ 'card-prefetch-ready': prefetchState[ws] === 'ready' }"
           :style="getWorkshopCardStyle(ws)">
 
           <!-- Color accent bar at top (always shown) -->
-          <div class="h-1.5 bg-gradient-to-r from-primary to-secondary" :style="getWorkshopBarStyle(ws)"></div>
+          <div class="h-1.5 relative overflow-hidden bg-gradient-to-r from-primary to-secondary" :style="getWorkshopBarStyle(ws)">
+            <!-- Loading shimmer: visible while prefetching -->
+            <div
+              v-if="prefetchState[ws] === 'loading'"
+              class="absolute inset-0 card-prefetch-shimmer"
+              aria-hidden="true"></div>
+          </div>
 
           <!-- Workshop thumbnail image (optional, no fallback) -->
           <div v-if="getWorkshopImage(ws)" class="overflow-hidden aspect-[16/9] bg-accent/20">
@@ -184,7 +192,7 @@ const emit = defineEmits(['update-title'])
 const router = useRouter()
 const route = useRoute()
 
-const { availableContent, isLoading, loadAvailableContent, loadWorkshopsForLanguage, removeContentSource, isRemoteWorkshop, isDefaultSource, getSourceForSlug, getWorkshopMeta, getContentSources } = useLessons()
+const { availableContent, isLoading, loadAvailableContent, loadWorkshopsForLanguage, loadAllLessonsForWorkshop, removeContentSource, isRemoteWorkshop, isDefaultSource, getSourceForSlug, getWorkshopMeta, getContentSources } = useLessons()
 const { selectedLanguage, setLanguage } = useLanguage()
 const { isWorkshopOffline } = useOffline()
 const { setDefaultManifest } = useManifest()
@@ -198,6 +206,36 @@ const workshopsLoading = ref(true)
 const activeFilters = ref(new Set())
 const copiedWorkshop = ref(null)
 const addedNotice = ref(null)
+
+// Prefetch status per workshop slug: 'loading' | 'ready'
+// Drives the shimmer-on-load and glow-on-ready visual feedback
+const prefetchState = ref({})
+
+function shouldSkipPrefetch(event) {
+  // Touch fires pointerenter on scroll — only Maus/Pen prefetchen
+  if (event.pointerType === 'touch') return true
+  const conn = navigator.connection
+  if (!conn) return false
+  if (conn.saveData) return true
+  if (conn.effectiveType === 'slow-2g' || conn.effectiveType === '2g') return true
+  return false
+}
+
+function handlePointerEnter(event, ws) {
+  if (shouldSkipPrefetch(event)) return
+  if (prefetchState.value[ws]) return // already loading or ready
+  prefetchState.value = { ...prefetchState.value, [ws]: 'loading' }
+  loadAllLessonsForWorkshop(learning.value, ws)
+    .then(() => {
+      prefetchState.value = { ...prefetchState.value, [ws]: 'ready' }
+    })
+    .catch(() => {
+      // Best-effort — drop state so a retry can happen on next hover
+      const next = { ...prefetchState.value }
+      delete next[ws]
+      prefetchState.value = next
+    })
+}
 const favorites = ref(JSON.parse(localStorage.getItem('workshopFavorites') || '[]'))
 const activeWorkshops = ref(JSON.parse(localStorage.getItem('activeWorkshops') || '[]'))
 

--- a/src/views/WorkshopOverview.vue
+++ b/src/views/WorkshopOverview.vue
@@ -42,8 +42,9 @@
           :id="wsIndex === 0 ? 'tour-workshop-card' : undefined"
           :key="ws"
           @click="openWorkshop(ws)"
+          @pointerenter="handlePointerEnter($event, ws)"
           class="group cursor-pointer transition-all duration-200 hover:shadow-lg hover:-translate-y-0.5 hover:border-primary/50 overflow-hidden relative"
-          :class="{ 'workshop-card--premium': isPremiumWorkshop(ws) }"
+          :class="{ 'workshop-card--premium': isPremiumWorkshop(ws), 'card-prefetch-ready': prefetchState[ws] === 'ready' }"
           :style="getWorkshopCardStyle(ws)">
 
           <!-- Premium badge floating top-right -->
@@ -56,7 +57,13 @@
           </div>
 
           <!-- Color accent bar at top (always shown) -->
-          <div class="h-1.5 bg-gradient-to-r from-primary to-secondary" :style="getWorkshopBarStyle(ws)"></div>
+          <div class="h-1.5 relative overflow-hidden bg-gradient-to-r from-primary to-secondary" :style="getWorkshopBarStyle(ws)">
+            <!-- Loading shimmer: visible while prefetching -->
+            <div
+              v-if="prefetchState[ws] === 'loading'"
+              class="absolute inset-0 card-prefetch-shimmer"
+              aria-hidden="true"></div>
+          </div>
 
           <!-- Workshop thumbnail image (optional, no fallback) -->
           <div v-if="getWorkshopImage(ws)" class="overflow-hidden aspect-[16/9] bg-accent/20">
@@ -212,7 +219,7 @@ const emit = defineEmits(['update-title'])
 const router = useRouter()
 const route = useRoute()
 
-const { availableContent, isLoading, loadAvailableContent, loadWorkshopsForLanguage, removeContentSource, isRemoteWorkshop, isDefaultSource, getSourceForSlug, getWorkshopMeta, getContentSources } = useLessons()
+const { availableContent, isLoading, loadAvailableContent, loadWorkshopsForLanguage, loadAllLessonsForWorkshop, removeContentSource, isRemoteWorkshop, isDefaultSource, getSourceForSlug, getWorkshopMeta, getContentSources } = useLessons()
 const { selectedLanguage, setLanguage } = useLanguage()
 const { isWorkshopOffline } = useOffline()
 const { setDefaultManifest } = useManifest()
@@ -226,6 +233,36 @@ const workshopsLoading = ref(true)
 const activeFilters = ref(new Set())
 const copiedWorkshop = ref(null)
 const addedNotice = ref(null)
+
+// Prefetch status per workshop slug: 'loading' | 'ready'
+// Drives the shimmer-on-load and glow-on-ready visual feedback
+const prefetchState = ref({})
+
+function shouldSkipPrefetch(event) {
+  // Touch fires pointerenter on scroll — only Maus/Pen prefetchen
+  if (event.pointerType === 'touch') return true
+  const conn = navigator.connection
+  if (!conn) return false
+  if (conn.saveData) return true
+  if (conn.effectiveType === 'slow-2g' || conn.effectiveType === '2g') return true
+  return false
+}
+
+function handlePointerEnter(event, ws) {
+  if (shouldSkipPrefetch(event)) return
+  if (prefetchState.value[ws]) return // already loading or ready
+  prefetchState.value = { ...prefetchState.value, [ws]: 'loading' }
+  loadAllLessonsForWorkshop(learning.value, ws)
+    .then(() => {
+      prefetchState.value = { ...prefetchState.value, [ws]: 'ready' }
+    })
+    .catch(() => {
+      // Best-effort — drop state so a retry can happen on next hover
+      const next = { ...prefetchState.value }
+      delete next[ws]
+      prefetchState.value = next
+    })
+}
 const favorites = ref(JSON.parse(localStorage.getItem('workshopFavorites') || '[]'))
 const activeWorkshops = ref(JSON.parse(localStorage.getItem('activeWorkshops') || '[]'))
 


### PR DESCRIPTION
Closes #124

## Was

Workshop-Karten laden Lessons im Hintergrund, sobald der Maus-Cursor sie berührt. Beim Klick navigiert die App dadurch **ohne sichtbare Wartezeit**.

## Warum

Heute sieht der User nach jedem Klick auf eine Workshop-Karte einen Spinner. Die 200–500ms zwischen Hover-Beginn und Klick reichen aus, um die Daten vorab zu laden — der Klick fühlt sich danach instant an.

## Wo

- `src/views/WorkshopOverview.vue` — `pointerenter` Handler + `prefetchState` (`loading` | `ready`)
- `src/style.css` — Shimmer + Glow Keyframes, `prefers-reduced-motion` Fallback
- `specs/workshop-card-prefetch.md` — Spec (Verhalten, Mobile, Daten-Schonmodus)
- `CHANGELOG.md` — Eintrag 2026-04-29

## Wow-Effekt — drei Zustände

| Status | Auslöser | Visuell |
|---|---|---|
| `idle` | Default | Standard-Karte |
| `loading` | Hover, Daten kommen | **Shimmer** wandert über den Akzent-Balken |
| `ready` | Daten im Cache | **Glow-Pulse** am Karten-Rand (Primary) |

## Schutzmaßnahmen

- **Touch-Geräte**: `pointerType === 'touch'` → kein Prefetch (sonst feuert jeder Scroll)
- **Save-Data**: respektiert `navigator.connection.saveData`
- **Schwaches Netz**: `slow-2g` und `2g` werden übersprungen
- **Reduced Motion**: Animationen werden abgeschaltet, Inhalt bleibt sichtbar
- **Memoization**: `loadAllLessonsForWorkshop` ist bereits gecached → keine doppelten Requests

## Test-Anleitung

Dev-Server starten:

\`\`\`bash
pnpm dev
\`\`\`

Öffnen: http://localhost:5173/#/deutsch

1. **Hover über eine Workshop-Karte** → Shimmer im farbigen Balken oben
2. Nach Sekundenbruchteil: **Glow-Pulse am Karten-Rand**
3. Maus weg, dann zurück → sofort `ready` (Cache, kein Shimmer)
4. **Klick** → Lessons-Grid erscheint sofort, kein Spinner
5. **DevTools → Slow 3G** → Effekt deutlich sichtbar
6. **DevTools → Mobile-Simulation (Touch)** → kein Hover-Trigger, normales Verhalten

## Build & Tests

- ✅ `pnpm build` erfolgreich
- ✅ `npx vitest --run` — 376 Tests grün