### PR TITLE
perf: cache-first loading for instant lesson loads (#122)

### DIFF
--- a/src/composables/useLessons.js
+++ b/src/composables/useLessons.js
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import yaml from 'js-yaml'
 import { useGun } from './useGun'
+import { cachedFetch } from '../lib/cachedFetch'
 
 // Helper function to resolve IPFS URLs to HTTP gateway URLs
 function resolveUrl(urlOrPath) {
@@ -193,7 +194,7 @@ export function useLessons() {
       }
 
 
-      const response = await fetch(fetchUrl)
+      const response = await cachedFetch(fetchUrl, 'network-first')
       if (!response.ok) {
         console.warn(`⚠️ Failed to fetch ${fetchUrl}: ${response.status}`)
         return
@@ -229,7 +230,7 @@ export function useLessons() {
         for (const filename of ['workshops.yaml', 'topics.yaml']) {
           const workshopsUrl = `${baseUrl}/${langKey}/${filename}`
           try {
-            const workshopsResponse = await fetch(workshopsUrl)
+            const workshopsResponse = await cachedFetch(workshopsUrl, 'network-first')
             if (!workshopsResponse.ok) continue
             const workshopsText = await workshopsResponse.text()
             workshopsData = yaml.load(workshopsText)
@@ -556,7 +557,7 @@ export function useLessons() {
         lessonsUrl = `${workshop}/lessons.yaml`
       }
 
-      const response = await fetch(lessonsUrl)
+      const response = await cachedFetch(lessonsUrl, 'network-first')
 
       if (!response.ok) {
         throw new Error(`Failed to fetch lessons.yaml for ${lang}/${workshop}: ${response.status}`)
@@ -606,7 +607,7 @@ export function useLessons() {
         lessonPath = `${workshop}/${source.path}/content.yaml`
       }
 
-      const response = await fetch(lessonPath)
+      const response = await cachedFetch(lessonPath, 'cache-first')
 
       if (!response.ok) {
         console.error(`❌ Failed to fetch lesson ${lessonPath}: ${response.status}`)

--- a/src/lib/cachedFetch.js
+++ b/src/lib/cachedFetch.js
@@ -1,0 +1,76 @@
+const CACHE_NAME = 'workshop-content'
+
+/**
+ * Fetch with cache strategy.
+ *
+ * 'network-first'         — Try network → on success update cache → on failure use cache.
+ *                           Best for YAML files that may change.
+ *
+ * 'cache-first'           — Serve from cache immediately if available, always revalidate
+ *                           in the background (stale-while-revalidate).
+ *                           Best for audio and images that rarely change.
+ *
+ * Local/relative URLs (/__local/…) are never cached — they come from the Vite
+ * dev plugin and are already instant.
+ */
+export async function cachedFetch(url, strategy = 'network-first') {
+  // Skip caching for local dev and data URLs
+  if (url.startsWith('/__') || url.startsWith('data:')) {
+    return fetch(url)
+  }
+
+  // Skip if Cache API is unavailable (e.g. non-secure context)
+  if (typeof caches === 'undefined') {
+    return fetch(url)
+  }
+
+  if (strategy === 'cache-first') {
+    return cacheFirst(url)
+  }
+  return networkFirst(url)
+}
+
+async function networkFirst(url) {
+  try {
+    const response = await fetch(url)
+    if (response.ok) {
+      // Update cache in the background — don't block the caller
+      updateCache(url, response.clone()).catch(() => {})
+    }
+    return response
+  } catch {
+    // Network failed — try cache as fallback
+    const cached = await fromCache(url)
+    if (cached) return cached
+    throw new Error(`Network request failed and no cache available for ${url}`)
+  }
+}
+
+async function cacheFirst(url) {
+  const cached = await fromCache(url)
+  if (cached) {
+    // Serve from cache immediately, revalidate in the background
+    fetch(url).then(r => { if (r.ok) updateCache(url, r).catch(() => {}) }).catch(() => {})
+    return cached
+  }
+  // Nothing cached yet — fetch from network and populate cache
+  const response = await fetch(url)
+  if (response.ok) {
+    updateCache(url, response.clone()).catch(() => {})
+  }
+  return response
+}
+
+async function fromCache(url) {
+  try {
+    const cache = await caches.open(CACHE_NAME)
+    return await cache.match(url) || null
+  } catch {
+    return null
+  }
+}
+
+async function updateCache(url, response) {
+  const cache = await caches.open(CACHE_NAME)
+  await cache.put(url, response)
+}


### PR DESCRIPTION
## Was

Fügt `src/lib/cachedFetch.js` hinzu — eine kleine Utility mit zwei Strategien:

| Strategie | Für | Verhalten |
|-----------|-----|-----------|
| `cache-first` | `content.yaml` (Lektionsinhalte) | Sofort aus Cache, Background-Revalidierung |
| `network-first` | `index.yaml`, `workshops.yaml`, `lessons.yaml` | Immer frisch, Cache als Offline-Fallback |

## Warum

Bisher: Jeder Seitenaufruf lud alles vom Netzwerk — auch wenn die Daten bereits im Cache (aus "Offline speichern") lagen.

Nach diesem PR: Wiederkehrende Nutzer sehen Lektionen **sofort**, während frische Daten im Hintergrund geladen werden (stale-while-revalidate).

## Auswirkung

- Kein sichtbarer Unterschied beim ersten Besuch
- Schnellerer Load für alle Nutzer die einen Workshop bereits besucht haben
- Automatischer Offline-Fallback ohne manuelle Download-Aktion

## Testen

1. Workshop öffnen → Netzwerk-Tab im Browser: `content.yaml` wird geladen und gecacht
2. Seite neu laden → `content.yaml` kommt aus Cache (kein Netzwerk-Request)
3. Offline gehen → Workshop lädt weiterhin aus Cache

Closes #122