### PR TITLE
feat: workshop video hero + coming-soon trailer für alle Workshops (#272)

### DIFF
--- a/src/components/LessonCard.vue
+++ b/src/components/LessonCard.vue
@@ -25,7 +25,7 @@
     ]"></div>
 
     <!-- Thumbnail -->
-    <div v-if="imageUrl" class="relative flex-shrink-0 w-24 sm:w-28 overflow-hidden">
+    <div v-if="imageUrl" class="relative flex-shrink-0 w-20 sm:w-24 h-20 sm:h-24 overflow-hidden">
       <img
         :src="imageUrl"
         :alt="lesson.title"

--- a/src/components/WorkshopHeroVideo.vue
+++ b/src/components/WorkshopHeroVideo.vue
@@ -1,0 +1,521 @@
+<template>
+  <div
+    ref="heroEl"
+    @mouseenter="onHover(true)"
+    @mouseleave="onHover(false)"
+    class="hero-video-container relative w-full overflow-hidden rounded-2xl shadow-2xl cursor-pointer group"
+    :style="{
+      height: heroHeight + 'px',
+      transform: `scale(${heroScale})`,
+      transformOrigin: 'top center',
+      transition: 'height 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
+    }"
+    @click="onTap"
+    @touchstart.passive="onTouchStart"
+    @touchmove.passive="onTouchMove"
+    @touchend.passive="onTouchEnd"
+  >
+    <!-- Animierter SVG-Hintergrund: Berg + Himmel + Aurora -->
+    <svg
+      class="absolute inset-0 w-full h-full"
+      viewBox="0 0 1280 720"
+      preserveAspectRatio="xMidYMid slice"
+    >
+      <defs>
+        <!-- Nachthimmel-Gradient -->
+        <linearGradient id="skyGrad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stop-color="#0c1b3a" />
+          <stop offset="0.5" stop-color="#1e1b4b" />
+          <stop offset="1" stop-color="#312e81" />
+        </linearGradient>
+        <!-- Aurora-Gradient -->
+        <linearGradient id="auroraGrad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stop-color="#10b981" stop-opacity="0" />
+          <stop offset="0.5" stop-color="#10b981" stop-opacity="0.4" />
+          <stop offset="1" stop-color="#06b6d4" stop-opacity="0" />
+        </linearGradient>
+        <linearGradient id="auroraGrad2" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stop-color="#a855f7" stop-opacity="0" />
+          <stop offset="0.5" stop-color="#a855f7" stop-opacity="0.35" />
+          <stop offset="1" stop-color="#3b82f6" stop-opacity="0" />
+        </linearGradient>
+        <!-- Schneeboden -->
+        <linearGradient id="snowGrad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stop-color="#dbeafe" />
+          <stop offset="1" stop-color="#94a3b8" />
+        </linearGradient>
+        <!-- Berg-Gradient -->
+        <linearGradient id="mountainGrad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stop-color="#3730a3" />
+          <stop offset="0.5" stop-color="#1e1b4b" />
+          <stop offset="1" stop-color="#0f172a" />
+        </linearGradient>
+        <!-- Terminal-Glow -->
+        <radialGradient id="terminalGlow">
+          <stop offset="0" stop-color="#10b981" stop-opacity="0.6" />
+          <stop offset="1" stop-color="#10b981" stop-opacity="0" />
+        </radialGradient>
+      </defs>
+
+      <!-- Himmel -->
+      <rect width="1280" height="720" fill="url(#skyGrad)" />
+
+      <!-- Sterne (statisch geseedet, twinkle via opacity) -->
+      <g class="stars">
+        <circle v-for="(s, i) in stars" :key="'s' + i"
+          :cx="s.x" :cy="s.y" :r="s.r"
+          :fill="'#ffffff'"
+          :opacity="0.3 + Math.sin(animFrame * 0.05 + s.phase) * 0.4 + 0.4" />
+      </g>
+
+      <!-- Mond -->
+      <g>
+        <circle cx="1050" cy="140" r="50" fill="#fef3c7" />
+        <circle cx="1050" cy="140" r="80" fill="#fef3c7" opacity="0.15" />
+        <circle cx="1080" cy="125" r="6" fill="#cbd5e1" opacity="0.4" />
+        <circle cx="1035" cy="155" r="4" fill="#cbd5e1" opacity="0.4" />
+      </g>
+
+      <!-- Aurora-Wellen (animiert) -->
+      <path
+        :d="`M 0 ${180 + Math.sin(animFrame * 0.02) * 20}
+             Q 320 ${230 + Math.sin(animFrame * 0.02 + 1) * 30}
+               640 ${190 + Math.sin(animFrame * 0.02 + 2) * 25}
+             T 1280 ${200 + Math.sin(animFrame * 0.02 + 3) * 20}
+             L 1280 360 L 0 360 Z`"
+        fill="url(#auroraGrad)"
+        opacity="0.7"
+      />
+      <path
+        :d="`M 0 ${220 + Math.sin(animFrame * 0.025 + 2) * 25}
+             Q 400 ${280 + Math.sin(animFrame * 0.025 + 3) * 30}
+               800 ${240 + Math.sin(animFrame * 0.025 + 4) * 20}
+             T 1280 ${260 + Math.sin(animFrame * 0.025 + 5) * 30}
+             L 1280 400 L 0 400 Z`"
+        fill="url(#auroraGrad2)"
+        opacity="0.6"
+      />
+
+      <!-- Hintergrund-Berge -->
+      <polygon
+        points="0,500 180,320 360,400 540,280 720,360 900,250 1080,330 1280,290 1280,720 0,720"
+        fill="url(#mountainGrad)"
+        opacity="0.7"
+      />
+      <!-- Vordere Berge -->
+      <polygon
+        points="0,560 220,400 440,460 640,360 840,440 1040,380 1280,420 1280,720 0,720"
+        fill="#0f172a"
+        opacity="0.85"
+      />
+      <!-- Schnee-Spitzen -->
+      <polygon points="200,420 220,400 240,420" fill="#fff" opacity="0.8" />
+      <polygon points="620,380 640,360 660,380" fill="#fff" opacity="0.8" />
+      <polygon points="1020,400 1040,380 1060,400" fill="#fff" opacity="0.8" />
+
+      <!-- Schneeboden -->
+      <ellipse cx="640" cy="720" rx="900" ry="120" fill="url(#snowGrad)" />
+
+      <!-- Schwebende Code-Snippets als Particles (Linux-Vibe) -->
+      <g class="code-particles">
+        <text
+          v-for="(p, i) in codeParticles" :key="'cp' + i"
+          :x="p.x"
+          :y="p.y + Math.sin(animFrame * 0.03 + p.phase) * 8"
+          :font-size="p.size"
+          :fill="p.color"
+          :opacity="p.opacity"
+          font-family="monospace"
+        >{{ p.text }}</text>
+      </g>
+
+      <!-- Terminal-Glow Bereich -->
+      <ellipse cx="640" cy="560" rx="400" ry="120" fill="url(#terminalGlow)" />
+
+      <!-- Großer Pinguin (Tux-inspiriert) — nur für Linux -->
+      <g v-if="showPenguin" :transform="`translate(580, 460) scale(${1 + Math.sin(animFrame * 0.04) * 0.015})`">
+        <!-- Schatten -->
+        <ellipse cx="60" cy="220" rx="80" ry="10" fill="#000" opacity="0.4" />
+
+        <!-- Körper (rundlich) -->
+        <ellipse cx="60" cy="135" rx="65" ry="85" fill="#1e293b" />
+
+        <!-- Weißer Bauch -->
+        <ellipse cx="60" cy="150" rx="48" ry="68" fill="#fff" />
+
+        <!-- Kopf (rund, etwas oben aufgesetzt) -->
+        <ellipse cx="60" cy="55" rx="55" ry="50" fill="#1e293b" />
+
+        <!-- Augen -->
+        <ellipse cx="40" cy="50" rx="14" ry="16" fill="#fff" />
+        <ellipse cx="80" cy="50" rx="14" ry="16" fill="#fff" />
+        <!-- Pupillen — Animation: schauen leicht hin und her -->
+        <circle
+          :cx="40 + Math.sin(animFrame * 0.015) * 3"
+          :cy="52"
+          r="6"
+          fill="#0f172a"
+        />
+        <circle
+          :cx="80 + Math.sin(animFrame * 0.015) * 3"
+          :cy="52"
+          r="6"
+          fill="#0f172a"
+        />
+        <!-- Augen-Glanz -->
+        <circle cx="42" cy="48" r="2" fill="#fff" />
+        <circle cx="82" cy="48" r="2" fill="#fff" />
+        <!-- Augen-Blinzeln Overlay -->
+        <rect
+          v-if="isBlinking"
+          x="26" y="48" width="68" height="6"
+          fill="#1e293b"
+        />
+
+        <!-- Gelber Schnabel -->
+        <polygon points="50,75 60,82 70,75 60,68" fill="#fbbf24" />
+        <polygon points="50,75 60,82 70,75" fill="#f59e0b" />
+
+        <!-- Linker Arm/Flosse (winkt) -->
+        <g :transform="`rotate(${Math.sin(animFrame * 0.08) * 12 - 5} 8 95)`">
+          <ellipse cx="-2" cy="125" rx="14" ry="38" fill="#1e293b" />
+        </g>
+
+        <!-- Rechter Arm/Flosse -->
+        <g :transform="`rotate(${Math.sin(animFrame * 0.08 + 1) * 8 + 3} 112 95)`">
+          <ellipse cx="122" cy="125" rx="14" ry="38" fill="#1e293b" />
+        </g>
+
+        <!-- Füße (gelb-orange) -->
+        <ellipse cx="30" cy="215" rx="22" ry="9" fill="#fbbf24" />
+        <ellipse cx="90" cy="215" rx="22" ry="9" fill="#fbbf24" />
+      </g>
+
+      <!-- Floating Linux-Symbole (subtil) -->
+      <g class="floating-symbols">
+        <text
+          v-for="(s, i) in symbols" :key="'sym' + i"
+          :x="s.x + Math.sin(animFrame * 0.02 + s.phase) * 12"
+          :y="s.y + Math.cos(animFrame * 0.02 + s.phase) * 8"
+          :font-size="s.size"
+          :fill="s.color"
+          :opacity="0.4 + Math.sin(animFrame * 0.03 + s.phase) * 0.2"
+          font-family="monospace"
+          font-weight="700"
+        >{{ s.char }}</text>
+      </g>
+    </svg>
+
+    <!-- Title-Overlay -->
+    <div class="absolute inset-x-0 bottom-0 p-6 sm:p-10 bg-gradient-to-t from-black/80 via-black/40 to-transparent">
+      <div class="max-w-4xl">
+        <div class="flex items-center gap-2 mb-2">
+          <span class="inline-block px-3 py-1 text-xs font-bold tracking-widest text-emerald-400 bg-emerald-400/10 rounded-full uppercase">
+            {{ workshopLabel }}
+          </span>
+          <span class="text-xs text-slate-300/70">{{ lessonCountLabel }}</span>
+        </div>
+        <h1 class="text-3xl sm:text-5xl font-extrabold text-white drop-shadow-2xl mb-2 leading-tight">
+          {{ title }}
+        </h1>
+        <p class="text-base sm:text-lg text-slate-200/90 mb-4 max-w-2xl">
+          {{ description }}
+        </p>
+        <div class="flex items-center gap-3 flex-wrap">
+          <button
+            @click.stop="$emit('start')"
+            class="flex items-center gap-2 px-6 py-3 bg-emerald-500 hover:bg-emerald-400 text-slate-900 font-bold rounded-xl shadow-lg shadow-emerald-500/30 transition-all hover:scale-105"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
+            {{ playLabel }}
+          </button>
+          <div class="text-sm text-slate-300/80">
+            {{ durationLabel }}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Hover-Glow Border -->
+    <div
+      class="absolute inset-0 rounded-2xl ring-2 ring-emerald-400/0 group-hover:ring-emerald-400/60 transition-all pointer-events-none"
+      :style="{
+        boxShadow: hovered ? '0 0 80px rgba(16,185,129,0.4)' : 'none',
+      }"
+    />
+
+    <!-- Scroll-Hint unten -->
+    <div
+      v-if="scrollY < 50 && !controlsVisible"
+      class="absolute bottom-2 right-4 text-xs text-slate-300/60 flex items-center gap-1 animate-bounce"
+    >
+      <span>{{ scrollLabel }}</span>
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+    </div>
+
+    <!-- Touch Controls Overlay -->
+    <Transition name="ctrl">
+      <div v-if="controlsVisible" class="ctrl-overlay absolute inset-0 flex flex-col justify-between" @click.stop>
+        <!-- Center controls -->
+        <div class="flex-1 flex items-center justify-center gap-6 sm:gap-10">
+          <button class="ctrl-btn ctrl-btn--skip" @click.stop="skip(-15)">
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/><text x="50%" y="68%" text-anchor="middle" font-size="6" font-family="monospace" fill="currentColor">15</text></svg>
+          </button>
+          <button class="ctrl-btn ctrl-btn--play" @click.stop="$emit('start')">
+            <svg v-if="!isPlaying" width="36" height="36" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
+            <svg v-else width="36" height="36" viewBox="0 0 24 24" fill="currentColor"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>
+          </button>
+          <button class="ctrl-btn ctrl-btn--skip" @click.stop="skip(+15)">
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M12 5V1l5 5-5 5V7c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6h2c0 4.42-3.58 8-8 8s-8-3.58-8-8 3.58-8 8-8z"/><text x="50%" y="68%" text-anchor="middle" font-size="6" font-family="monospace" fill="currentColor">15</text></svg>
+          </button>
+        </div>
+        <!-- Progress / scrub bar -->
+        <div class="ctrl-progress" @click.stop>
+          <div class="ctrl-progress-track"
+            @click.stop="onProgressClick"
+            @touchstart.prevent.stop="onScrubStart"
+            @touchmove.prevent.stop="onScrubMove">
+            <div class="ctrl-progress-fill" :style="{ width: scrubProgress + '%' }"></div>
+            <div class="ctrl-progress-thumb" :style="{ left: scrubProgress + '%' }"></div>
+          </div>
+          <div class="ctrl-time">
+            <span>{{ formatTime(currentSec) }}</span>
+            <span>{{ formatTime(totalSec) }}</span>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted, onBeforeUnmount } from 'vue'
+
+const props = defineProps({
+  title:        { type: String,  default: 'Workshop' },
+  description:  { type: String,  default: '' },
+  lessonCount:  { type: Number,  default: 10 },
+  totalMinutes: { type: Number,  default: 12 },
+  workshopLabel:{ type: String,  default: 'Workshop' },
+  playLabel:    { type: String,  default: '▶  Starten' },
+  durationLabel:{ type: String,  default: '' },
+  scrollLabel:  { type: String,  default: 'Lektionen entdecken' },
+  showPenguin:  { type: Boolean, default: false },
+})
+
+defineEmits(['start'])
+
+// ── Touch Controls ────────────────────────────────────────────────────────────
+const controlsVisible = ref(false)
+const isPlaying = ref(false)
+const scrubProgress = ref(0)
+const totalSec = computed(() => props.totalMinutes * 60)
+const currentSec = computed(() => Math.round(scrubProgress.value / 100 * totalSec.value))
+let hideTimer = null
+
+function showControls() {
+  controlsVisible.value = true
+  clearTimeout(hideTimer)
+  hideTimer = setTimeout(() => { controlsVisible.value = false }, 3500)
+}
+
+function onTap() {
+  if (!controlsVisible.value) {
+    showControls()
+  } else {
+    // Second tap = toggle play (for placeholder: just emit start)
+    controlsVisible.value = false
+  }
+}
+
+function skip(seconds) {
+  const pct = (seconds / totalSec.value) * 100
+  scrubProgress.value = Math.max(0, Math.min(100, scrubProgress.value + pct))
+  showControls()
+}
+
+// Swipe-to-scrub on the video body
+let touchStartX = 0
+let touchStartProgress = 0
+function onTouchStart(e) {
+  touchStartX = e.touches[0].clientX
+  touchStartProgress = scrubProgress.value
+}
+function onTouchMove(e) {
+  const dx = e.touches[0].clientX - touchStartX
+  const width = heroEl.value?.offsetWidth || 300
+  const pctDelta = (dx / width) * 100
+  scrubProgress.value = Math.max(0, Math.min(100, touchStartProgress + pctDelta))
+  showControls()
+}
+function onTouchEnd() {}
+
+// Click on progress bar
+function onProgressClick(e) {
+  const rect = e.currentTarget.getBoundingClientRect()
+  scrubProgress.value = ((e.clientX - rect.left) / rect.width) * 100
+  showControls()
+}
+function onScrubStart(e) {
+  touchStartX = e.touches[0].clientX
+  touchStartProgress = scrubProgress.value
+}
+function onScrubMove(e) {
+  const rect = e.currentTarget.getBoundingClientRect()
+  scrubProgress.value = Math.max(0, Math.min(100, ((e.touches[0].clientX - rect.left) / rect.width) * 100))
+}
+
+function formatTime(s) {
+  const m = Math.floor(s / 60)
+  const sec = Math.floor(s % 60)
+  return `${m}:${sec.toString().padStart(2, '0')}`
+}
+
+const heroEl = ref(null)
+const scrollY = ref(0)
+const hovered = ref(false)
+const animFrame = ref(0)
+
+// Sterne, Code-Particles, Symbole — beim Mount einmal generieren
+const stars = ref(
+  Array.from({ length: 60 }, (_, i) => ({
+    x: (i * 137.5 + 23) % 1280,
+    y: (i * 83.7 + 17) % 400,
+    r: 0.8 + (i % 4) * 0.5,
+    phase: i * 0.3,
+  }))
+)
+
+const codeColors = ['#10b981', '#06b6d4', '#a855f7', '#fbbf24']
+const codeSnippets = ['ls', 'cd ~', 'sudo', 'apt', 'grep', 'mkdir', 'rm -rf', 'echo', 'cat', '|', 'chmod', 'ssh', 'top', 'kill', 'tar', 'curl', 'vim']
+const codeParticles = ref(
+  Array.from({ length: 16 }, (_, i) => ({
+    x: ((i * 79) % 1180) + 50,
+    y: 480 + (i % 5) * 30,
+    size: 12 + (i % 3) * 4,
+    color: codeColors[i % codeColors.length],
+    opacity: 0.25 + (i % 4) * 0.1,
+    phase: i * 0.5,
+    text: codeSnippets[i % codeSnippets.length],
+  }))
+)
+
+const symbols = ref(
+  ['$', '~', '/', '#', '>', '_', '|'].map((char, i) => ({
+    x: 80 + i * 170,
+    y: 80 + (i % 3) * 60,
+    size: 24 + (i % 3) * 10,
+    color: codeColors[i % codeColors.length],
+    char,
+    phase: i * 0.4,
+  }))
+)
+
+// Blink-Cycle
+const isBlinking = computed(() => {
+  const c = animFrame.value % 100
+  return c > 95 && c < 100
+})
+
+// Feste Höhe — kein Sticky mehr
+const heroHeight = computed(() => 460)
+const heroScale = computed(() => (hovered.value ? 1.01 : 1))
+
+// Lessons-Count-Label
+const lessonCountLabel = computed(() => `${props.lessonCount} Lektionen`)
+
+function onHover(state) {
+  hovered.value = state
+}
+
+function onScroll() {
+  scrollY.value = window.scrollY
+}
+
+let rafId = null
+function tick() {
+  animFrame.value += 1
+  rafId = requestAnimationFrame(tick)
+}
+
+onMounted(() => {
+  window.addEventListener('scroll', onScroll, { passive: true })
+  rafId = requestAnimationFrame(tick)
+})
+onBeforeUnmount(() => {
+  window.removeEventListener('scroll', onScroll)
+  if (rafId) cancelAnimationFrame(rafId)
+})
+</script>
+
+<style scoped>
+.hero-video-container {
+  background: linear-gradient(180deg, #0c1b3a 0%, #1e1b4b 100%);
+  will-change: transform;
+}
+
+/* Cinema bars */
+.hero-video-container::before,
+.hero-video-container::after {
+  content: '';
+  position: absolute;
+  left: 0; right: 0; height: 8px;
+  z-index: 10; pointer-events: none;
+}
+.hero-video-container::before { top: 0; background: linear-gradient(to bottom, rgba(0,0,0,0.4), transparent); }
+.hero-video-container::after  { bottom: 0; background: linear-gradient(to top, rgba(0,0,0,0.4), transparent); }
+
+/* ── Controls overlay ── */
+.ctrl-overlay {
+  background: rgba(0,0,0,0.45);
+  backdrop-filter: blur(2px);
+  z-index: 20;
+  padding: 20px 16px 16px;
+}
+
+/* Transition */
+.ctrl-enter-active, .ctrl-leave-active { transition: opacity .25s ease; }
+.ctrl-enter-from, .ctrl-leave-to { opacity: 0; }
+
+/* Buttons */
+.ctrl-btn {
+  display: flex; align-items: center; justify-content: center;
+  border: none; cursor: pointer; border-radius: 50%;
+  color: #fff; transition: transform .15s, background .15s;
+}
+.ctrl-btn--play {
+  width: 72px; height: 72px;
+  background: rgba(255,255,255,0.18);
+  box-shadow: 0 0 0 2px rgba(255,255,255,.3), 0 8px 32px rgba(0,0,0,.4);
+}
+.ctrl-btn--play:active { transform: scale(0.92); }
+.ctrl-btn--skip {
+  width: 52px; height: 52px;
+  background: rgba(255,255,255,0.1);
+}
+.ctrl-btn--skip:active { transform: scale(0.9); }
+.ctrl-btn--skip svg text { font-size: 5px; }
+
+/* Progress bar */
+.ctrl-progress { padding: 0 4px 4px; }
+.ctrl-progress-track {
+  position: relative; height: 4px; border-radius: 4px;
+  background: rgba(255,255,255,.25); cursor: pointer; touch-action: none;
+}
+.ctrl-progress-fill {
+  position: absolute; top: 0; left: 0; height: 100%;
+  background: #10b981; border-radius: 4px;
+  pointer-events: none;
+}
+.ctrl-progress-thumb {
+  position: absolute; top: 50%; transform: translate(-50%, -50%);
+  width: 14px; height: 14px; border-radius: 50%;
+  background: #fff; box-shadow: 0 0 6px rgba(0,0,0,.4);
+  pointer-events: none;
+}
+.ctrl-time {
+  display: flex; justify-content: space-between;
+  font-size: 11px; color: rgba(255,255,255,.7);
+  margin-top: 6px; font-family: monospace; letter-spacing: .04em;
+}
+</style>

--- a/src/components/WorkshopTrailer.vue
+++ b/src/components/WorkshopTrailer.vue
@@ -1,0 +1,514 @@
+<template>
+  <Teleport to="body">
+    <div class="trl-overlay" @click="onClose">
+      <canvas ref="canvasEl" class="trl-canvas"></canvas>
+
+      <!-- Text layers -->
+      <div class="trl-ui" @click.stop>
+
+        <!-- Scene 1: Teaser badge -->
+        <div class="trl-scene" :class="{ 'trl-scene--in': scene >= 1, 'trl-scene--out': scene > 1 }">
+          <div class="trl-badge">
+            <span class="trl-badge-dot"></span>
+            {{ isDE ? 'Linux · Workshop' : 'Linux · Workshop' }}
+          </div>
+        </div>
+
+        <!-- Scene 2: Island builds + title -->
+        <div class="trl-scene trl-scene--title" :class="{ 'trl-scene--in': scene >= 2, 'trl-scene--out': scene > 3 }">
+          <h1 class="trl-title">Linux<br>Grundlagen</h1>
+          <p class="trl-sub">{{ isDE ? 'Vom ersten Befehl zum Linux-Profi' : 'From first command to Linux pro' }}</p>
+        </div>
+
+        <!-- Scene 3: Stats -->
+        <div class="trl-scene trl-scene--stats" :class="{ 'trl-scene--in': scene >= 3, 'trl-scene--out': scene > 4 }">
+          <div class="trl-stats">
+            <div class="trl-stat">
+              <span class="trl-stat-n">12</span>
+              <span class="trl-stat-l">{{ isDE ? 'Lektionen' : 'Lessons' }}</span>
+            </div>
+            <div class="trl-stat-sep"></div>
+            <div class="trl-stat">
+              <span class="trl-stat-n">48</span>
+              <span class="trl-stat-l">{{ isDE ? 'Übungen' : 'Exercises' }}</span>
+            </div>
+            <div class="trl-stat-sep"></div>
+            <div class="trl-stat">
+              <span class="trl-stat-n">~4h</span>
+              <span class="trl-stat-l">{{ isDE ? 'Lernzeit' : 'Learning time' }}</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Scene 4: Coming Soon -->
+        <div class="trl-scene trl-scene--cs" :class="{ 'trl-scene--in': scene >= 4 }">
+          <div class="trl-cs-wrap">
+            <div class="trl-cs-glow"></div>
+            <div class="trl-cs-label">{{ isDE ? 'BALD VERFÜGBAR' : 'COMING SOON' }}</div>
+            <p class="trl-cs-sub">{{ isDE ? 'Das vollständige Video-Erlebnis' : 'The full video experience' }}</p>
+            <button class="trl-cs-btn" @click="$emit('close')">
+              {{ isDE ? '→ Jetzt mit Lektionen starten' : '→ Start with lessons now' }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Close -->
+      <button class="trl-close" @click.stop="$emit('close')" :aria-label="isDE ? 'Schließen' : 'Close'">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted, computed } from 'vue'
+
+const props = defineProps({
+  isDE:         { type: Boolean, default: true },
+  workshopTitle:{ type: String,  default: 'Linux Grundlagen' },
+})
+defineEmits(['close'])
+
+const canvasEl = ref(null)
+const scene    = ref(0)
+
+// ── Scene timeline ────────────────────────────────────────────────────────────
+const SCENES = [
+  { at: 400,  id: 1 },
+  { at: 1800, id: 2 },
+  { at: 3800, id: 3 },
+  { at: 6000, id: 4 },
+]
+const timers = []
+function startTimeline() {
+  SCENES.forEach(s => {
+    timers.push(setTimeout(() => { scene.value = s.id }, s.at))
+  })
+}
+
+function onClose() { /* overlay click does nothing — only X button and CTA close */ }
+
+// ── Canvas ────────────────────────────────────────────────────────────────────
+let ctx, W, H, raf
+let frame = 0
+
+// Deterministic pseudo-random
+function rand(seed) { return ((Math.sin(seed + 1) * 43758.5453) % 1 + 1) % 1 }
+
+// ── Star field ────────────────────────────────────────────────────────────────
+const STARS = Array.from({ length: 120 }, (_, i) => ({
+  x: rand(i * 3)     ,
+  y: rand(i * 3 + 1) ,
+  r: 0.5 + rand(i * 3 + 2) * 1.5,
+  sp: 0.3 + rand(i * 5) * 0.7,
+  ph: rand(i * 7) * Math.PI * 2,
+}))
+
+// ── Particles (code snippets) ─────────────────────────────────────────────────
+const CMDS = ['ls -la','sudo','cd ~','chmod 755','grep','mkdir','echo $PATH','cat','|','>','ssh','apt','top','vim','kill','curl','tar -xzf','pwd']
+const PARTS = Array.from({ length: 28 }, (_, i) => ({
+  x: rand(i * 11)     ,
+  y: rand(i * 11 + 1) ,
+  vx: (rand(i * 13) - 0.5) * 0.0008,
+  vy: -(0.0003 + rand(i * 17) * 0.0005),
+  a: 0.15 + rand(i * 19) * 0.45,
+  txt: CMDS[i % CMDS.length],
+  sz: 10 + rand(i * 23) * 6,
+  col: ['#10b981','#06b6d4','#a855f7','#f59e0b'][i % 4],
+}))
+
+// ── Isometric helpers ─────────────────────────────────────────────────────────
+function isoProject(gx, gy, gz, cx, cy, tileX, tileY) {
+  return {
+    x: cx + (gx - gy) * tileX,
+    y: cy + (gx + gy) * tileY * 0.5 - gz * tileY,
+  }
+}
+
+function drawCube(x, y, z, w, h, d, top, left, right) {
+  const T = 28, TX = 20
+  const cx = W * 0.5, cy = H * 0.52
+
+  const a = isoProject(x,   y,   z+d, cx, cy, T, TX)
+  const b = isoProject(x+w, y,   z+d, cx, cy, T, TX)
+  const c = isoProject(x+w, y+h, z+d, cx, cy, T, TX)
+  const d_ = isoProject(x, y+h, z+d, cx, cy, T, TX)
+  const e = isoProject(x,   y,   z,   cx, cy, T, TX)
+  const f = isoProject(x+w, y,   z,   cx, cy, T, TX)
+  const g = isoProject(x+w, y+h, z,   cx, cy, T, TX)
+
+  // Top face
+  ctx.beginPath()
+  ctx.moveTo(a.x, a.y); ctx.lineTo(b.x, b.y)
+  ctx.lineTo(c.x, c.y); ctx.lineTo(d_.x, d_.y)
+  ctx.closePath(); ctx.fillStyle = top; ctx.fill()
+
+  // Left face
+  ctx.beginPath()
+  ctx.moveTo(a.x, a.y); ctx.lineTo(d_.x, d_.y)
+  ctx.lineTo(g.x, g.y); ctx.lineTo(isoProject(x, y+h, z, cx, cy, T, TX).x, isoProject(x, y+h, z, cx, cy, T, TX).y)
+  ctx.closePath(); ctx.fillStyle = left; ctx.fill()
+
+  // Right face
+  ctx.beginPath()
+  ctx.moveTo(b.x, b.y); ctx.lineTo(c.x, c.y)
+  ctx.lineTo(g.x, g.y); ctx.lineTo(f.x, f.y)
+  ctx.closePath(); ctx.fillStyle = right; ctx.fill()
+}
+
+// ── Island layout ─────────────────────────────────────────────────────────────
+const ISLAND = [
+  // Base platform
+  { x:-3,y:-3,z:0,w:6,h:6,d:1,  top:'#1e3a5f',left:'#0f2040',right:'#162d4f' },
+  { x:-2,y:-2,z:1,w:4,h:4,d:0.6,top:'#234876',left:'#152e52',right:'#1a3a60' },
+  // Terminal block
+  { x:-1,y:-1,z:1.6,w:2,h:2,d:1.2,top:'#0d1f3c',left:'#091729',right:'#0b1c34' },
+  // Screen face (drawn separately as glowing rect)
+]
+
+// Screen face for terminal
+function drawScreen(alpha) {
+  const T = 28, TX = 20
+  const cx = W * 0.5, cy = H * 0.52
+  const x = -1, y = -1, z = 2.8, w = 2, d = 1.2
+
+  const a = isoProject(x+w, y,   z+d, cx, cy, T, TX)
+  const b = isoProject(x+w, y+d, z+d, cx, cy, T, TX)
+  const c = isoProject(x+w, y+d, z,   cx, cy, T, TX)
+  const f = isoProject(x+w, y,   z,   cx, cy, T, TX)
+
+  // Glow behind screen
+  const gx = (a.x + c.x) / 2
+  const gy = (a.y + c.y) / 2
+  const gr = ctx.createRadialGradient(gx, gy, 0, gx, gy, 60)
+  gr.addColorStop(0, `rgba(16,185,129,${0.35 * alpha})`)
+  gr.addColorStop(1, 'rgba(16,185,129,0)')
+  ctx.fillStyle = gr
+  ctx.beginPath(); ctx.arc(gx, gy, 60, 0, Math.PI * 2); ctx.fill()
+
+  // Screen
+  ctx.beginPath()
+  ctx.moveTo(a.x, a.y); ctx.lineTo(b.x, b.y)
+  ctx.lineTo(c.x, c.y); ctx.lineTo(f.x, f.y)
+  ctx.closePath()
+
+  const grad = ctx.createLinearGradient(f.x, f.y, a.x, a.y)
+  grad.addColorStop(0, `rgba(8,30,20,${alpha})`)
+  grad.addColorStop(1, `rgba(16,50,35,${alpha})`)
+  ctx.fillStyle = grad; ctx.fill()
+
+  // Scanlines
+  ctx.strokeStyle = `rgba(16,185,129,${0.12 * alpha})`
+  ctx.lineWidth = 1
+  const steps = 8
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps
+    const px = f.x + (a.x - f.x) * t
+    const py = f.y + (a.y - f.y) * t
+    const qx = c.x + (b.x - c.x) * t
+    const qy = c.y + (b.y - c.y) * t
+    ctx.beginPath(); ctx.moveTo(px, py); ctx.lineTo(qx, qy); ctx.stroke()
+  }
+
+  // Terminal text line
+  const lx = (f.x + a.x) / 2 - 18
+  const ly = (f.y + a.y + c.y + b.y) / 4
+  const blink = Math.floor(frame / 30) % 2 === 0
+  ctx.font = `bold 8px monospace`
+  ctx.fillStyle = `rgba(74,222,128,${0.9 * alpha})`
+  ctx.fillText(`$ _${blink ? '█' : ' '}`, lx, ly)
+}
+
+// ── Penguin (Tux) ─────────────────────────────────────────────────────────────
+function drawPenguin(alpha) {
+  const T = 28, TX = 20
+  const cx = W * 0.5, cy = H * 0.52
+  const pos = isoProject(-1.5, -1, 2.6, cx, cy, T, TX)
+  const px = pos.x, py = pos.y
+  const sc = Math.min(W, H) * 0.065
+  const bob = Math.sin(frame * 0.04) * sc * 0.08
+
+  ctx.save()
+  ctx.translate(px, py + bob)
+  ctx.scale(sc / 30, sc / 30)
+  ctx.globalAlpha = alpha
+
+  // Shadow
+  ctx.beginPath()
+  ctx.ellipse(0, 40, 22, 5, 0, 0, Math.PI * 2)
+  ctx.fillStyle = 'rgba(0,0,0,0.35)'; ctx.fill()
+
+  // Body
+  ctx.beginPath()
+  ctx.ellipse(0, 10, 18, 24, 0, 0, Math.PI * 2)
+  ctx.fillStyle = '#1e293b'; ctx.fill()
+
+  // Belly
+  ctx.beginPath()
+  ctx.ellipse(0, 14, 13, 19, 0, 0, Math.PI * 2)
+  ctx.fillStyle = '#f1f5f9'; ctx.fill()
+
+  // Head
+  ctx.beginPath()
+  ctx.ellipse(0, -18, 16, 15, 0, 0, Math.PI * 2)
+  ctx.fillStyle = '#1e293b'; ctx.fill()
+
+  // Eyes
+  ;[[-7, -20], [7, -20]].forEach(([ex, ey]) => {
+    ctx.beginPath(); ctx.ellipse(ex, ey, 5, 6, 0, 0, Math.PI * 2)
+    ctx.fillStyle = '#fff'; ctx.fill()
+    ctx.beginPath(); ctx.ellipse(ex + 1, ey + 1, 2.5, 2.5, 0, 0, Math.PI * 2)
+    ctx.fillStyle = '#0f172a'; ctx.fill()
+    ctx.beginPath(); ctx.ellipse(ex - 0.5, ey - 1, 0.8, 0.8, 0, 0, Math.PI * 2)
+    ctx.fillStyle = '#fff'; ctx.fill()
+  })
+
+  // Beak
+  ctx.beginPath()
+  ctx.moveTo(-4, -12); ctx.lineTo(0, -8); ctx.lineTo(4, -12); ctx.lineTo(0, -16)
+  ctx.closePath(); ctx.fillStyle = '#fbbf24'; ctx.fill()
+
+  // Flippers
+  const flapL = Math.sin(frame * 0.08) * 8
+  ctx.save(); ctx.rotate((-30 + flapL) * Math.PI / 180)
+  ctx.beginPath(); ctx.ellipse(-20, 5, 6, 17, 0, 0, Math.PI * 2)
+  ctx.fillStyle = '#1e293b'; ctx.fill(); ctx.restore()
+
+  ctx.save(); ctx.rotate((30 - flapL) * Math.PI / 180)
+  ctx.beginPath(); ctx.ellipse(20, 5, 6, 17, 0, 0, Math.PI * 2)
+  ctx.fillStyle = '#1e293b'; ctx.fill(); ctx.restore()
+
+  // Feet
+  ;[[-7, 37], [7, 37]].forEach(([fx, fy]) => {
+    ctx.beginPath(); ctx.ellipse(fx, fy, 8, 4, 0, 0, Math.PI * 2)
+    ctx.fillStyle = '#fbbf24'; ctx.fill()
+  })
+
+  ctx.restore()
+}
+
+// ── Aurora background ─────────────────────────────────────────────────────────
+function drawAurora() {
+  const t = frame * 0.008
+  ;[
+    { y: 0.25, amp: 0.06, col: [16, 185, 129], a: 0.18 },
+    { y: 0.35, amp: 0.08, col: [168, 85, 246], a: 0.13 },
+    { y: 0.3,  amp: 0.05, col: [6, 182, 212],  a: 0.12 },
+  ].forEach(({ y, amp, col, a }) => {
+    ctx.beginPath()
+    ctx.moveTo(0, H * y)
+    for (let x = 0; x <= W; x += 8) {
+      const wave = Math.sin(x / W * Math.PI * 3 + t) * amp + Math.sin(x / W * Math.PI * 5 + t * 1.3) * amp * 0.5
+      ctx.lineTo(x, H * (y + wave))
+    }
+    ctx.lineTo(W, H * 0.55); ctx.lineTo(0, H * 0.55); ctx.closePath()
+    ctx.fillStyle = `rgba(${col.join(',')},${a})`; ctx.fill()
+  })
+}
+
+// ── Main draw loop ────────────────────────────────────────────────────────────
+function draw() {
+  frame++
+  ctx.clearRect(0, 0, W, H)
+
+  // Sky gradient
+  const sky = ctx.createLinearGradient(0, 0, 0, H)
+  sky.addColorStop(0,   '#040d1a')
+  sky.addColorStop(0.5, '#07162e')
+  sky.addColorStop(1,   '#0a1f3f')
+  ctx.fillStyle = sky; ctx.fillRect(0, 0, W, H)
+
+  // Aurora
+  drawAurora()
+
+  // Stars
+  STARS.forEach(s => {
+    const bri = 0.4 + Math.sin(frame * s.sp * 0.05 + s.ph) * 0.4
+    ctx.beginPath()
+    ctx.arc(s.x * W, s.y * H, s.r, 0, Math.PI * 2)
+    ctx.fillStyle = `rgba(255,255,255,${bri})`; ctx.fill()
+  })
+
+  // Island build-up alpha: starts at frame 30 (~1s), fully visible by frame 90
+  const islandAlpha = Math.min(1, Math.max(0, (frame - 30) / 60))
+
+  if (islandAlpha > 0) {
+    ctx.globalAlpha = islandAlpha
+    ISLAND.forEach(b => drawCube(b.x, b.y, b.z, b.w, b.h, b.d, b.top, b.left, b.right))
+    ctx.globalAlpha = 1
+    drawScreen(islandAlpha)
+    drawPenguin(islandAlpha)
+  }
+
+  // Floating code particles
+  PARTS.forEach(p => {
+    p.x = (p.x + p.vx + 1) % 1
+    p.y = (p.y + p.vy + 1) % 1
+    ctx.font = `${p.sz}px monospace`
+    ctx.fillStyle = p.col
+    ctx.globalAlpha = p.a * Math.max(0.3, islandAlpha)
+    ctx.fillText(p.txt, p.x * W, p.y * H)
+    ctx.globalAlpha = 1
+  })
+
+  // Ground glow
+  const gnd = ctx.createRadialGradient(W * 0.5, H * 0.65, 0, W * 0.5, H * 0.65, W * 0.4)
+  gnd.addColorStop(0, `rgba(16,185,129,${0.12 * islandAlpha})`)
+  gnd.addColorStop(1, 'rgba(16,185,129,0)')
+  ctx.fillStyle = gnd; ctx.fillRect(0, H * 0.4, W, H * 0.6)
+
+  raf = requestAnimationFrame(draw)
+}
+
+function resize() {
+  if (!canvasEl.value) return
+  W = canvasEl.value.width  = canvasEl.value.offsetWidth
+  H = canvasEl.value.height = canvasEl.value.offsetHeight
+}
+
+onMounted(() => {
+  ctx = canvasEl.value.getContext('2d')
+  resize()
+  window.addEventListener('resize', resize)
+  draw()
+  startTimeline()
+})
+
+onUnmounted(() => {
+  cancelAnimationFrame(raf)
+  window.removeEventListener('resize', resize)
+  timers.forEach(clearTimeout)
+})
+</script>
+
+<style scoped>
+/* ── Overlay ── */
+.trl-overlay {
+  position: fixed; inset: 0; z-index: 1000;
+  display: flex; align-items: center; justify-content: center;
+  background: rgba(2,8,20,0.96);
+  backdrop-filter: blur(8px);
+}
+.trl-canvas {
+  position: absolute; inset: 0; width: 100%; height: 100%;
+}
+
+/* ── UI layer ── */
+.trl-ui {
+  position: relative; z-index: 2;
+  width: 100%; height: 100%;
+  display: flex; align-items: center; justify-content: center;
+  pointer-events: none;
+}
+
+/* ── Scenes ── */
+.trl-scene {
+  position: absolute; inset: 0;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity .7s ease, transform .7s ease;
+  pointer-events: none;
+}
+.trl-scene--in  { opacity: 1; transform: none; }
+.trl-scene--out { opacity: 0; transform: translateY(-12px); transition-duration: .5s; }
+.trl-scene--cs  { pointer-events: auto; }
+
+/* Scene 1: Badge */
+.trl-badge {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 20px; border-radius: 100px;
+  background: rgba(16,185,129,0.12);
+  border: 1px solid rgba(16,185,129,0.35);
+  font-size: 12px; font-weight: 800; letter-spacing: .12em;
+  text-transform: uppercase; color: #10b981;
+}
+.trl-badge-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: #10b981;
+  box-shadow: 0 0 8px #10b981;
+  animation: trl-pulse 1.5s ease-in-out infinite;
+}
+@keyframes trl-pulse { 0%,100%{opacity:1;transform:scale(1)} 50%{opacity:.5;transform:scale(1.4)} }
+
+/* Scene 2: Title */
+.trl-scene--title { top: auto; bottom: 12%; height: auto; justify-content: flex-end; }
+.trl-title {
+  font-size: clamp(44px, 10vw, 96px); font-weight: 900; line-height: 1.0;
+  text-align: center; color: #fff;
+  text-shadow: 0 0 60px rgba(16,185,129,0.5), 0 4px 32px rgba(0,0,0,0.6);
+  letter-spacing: -.02em;
+}
+.trl-sub {
+  margin-top: 12px; font-size: clamp(13px, 2.5vw, 18px);
+  color: rgba(148,213,255,0.75); text-align: center;
+  letter-spacing: .02em;
+}
+
+/* Scene 3: Stats */
+.trl-scene--stats { top: auto; bottom: 6%; height: auto; justify-content: flex-end; }
+.trl-stats {
+  display: flex; align-items: center; gap: 24px;
+  padding: 14px 28px; border-radius: 16px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08);
+  backdrop-filter: blur(4px);
+}
+.trl-stat { display: flex; flex-direction: column; align-items: center; gap: 2px; }
+.trl-stat-n {
+  font-size: clamp(20px, 4vw, 32px); font-weight: 900; color: #10b981;
+  line-height: 1; font-variant-numeric: tabular-nums;
+}
+.trl-stat-l { font-size: 10px; font-weight: 600; color: rgba(255,255,255,0.45); letter-spacing: .06em; text-transform: uppercase; }
+.trl-stat-sep { width: 1px; height: 36px; background: rgba(255,255,255,0.1); }
+
+/* Scene 4: Coming Soon */
+.trl-scene--cs { background: linear-gradient(to top, rgba(2,8,20,0.85), transparent 60%); }
+.trl-cs-wrap {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  padding: 40px 32px; max-width: 480px; text-align: center; position: relative;
+}
+.trl-cs-glow {
+  position: absolute; inset: 0; border-radius: 24px;
+  box-shadow: 0 0 80px rgba(16,185,129,0.25), inset 0 0 40px rgba(16,185,129,0.06);
+  border: 1px solid rgba(16,185,129,0.2);
+  animation: trl-cs-glow 3s ease-in-out infinite;
+}
+@keyframes trl-cs-glow {
+  0%,100% { box-shadow: 0 0 60px rgba(16,185,129,0.2), inset 0 0 30px rgba(16,185,129,0.05); }
+  50%     { box-shadow: 0 0 120px rgba(16,185,129,0.35), inset 0 0 60px rgba(16,185,129,0.1); }
+}
+.trl-cs-label {
+  font-size: clamp(28px, 7vw, 56px); font-weight: 900;
+  letter-spacing: .06em; color: #fff;
+  text-shadow: 0 0 40px rgba(16,185,129,0.6);
+  position: relative;
+}
+.trl-cs-sub {
+  font-size: 15px; color: rgba(148,213,255,0.7);
+  position: relative;
+}
+.trl-cs-btn {
+  margin-top: 8px; padding: 14px 28px; border-radius: 14px; border: none;
+  background: linear-gradient(135deg, #10b981, #059669);
+  color: #fff; font-size: 15px; font-weight: 800;
+  cursor: pointer; pointer-events: auto;
+  box-shadow: 0 8px 32px rgba(16,185,129,0.45);
+  transition: transform .15s, box-shadow .15s;
+  position: relative;
+}
+.trl-cs-btn:hover { transform: translateY(-2px); box-shadow: 0 12px 40px rgba(16,185,129,0.55); }
+.trl-cs-btn:active { transform: translateY(0); }
+
+/* ── Close button ── */
+.trl-close {
+  position: absolute; top: 20px; right: 20px; z-index: 3;
+  width: 40px; height: 40px; border-radius: 50%; border: none;
+  background: rgba(255,255,255,0.08); color: rgba(255,255,255,0.7);
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer; transition: background .2s, color .2s;
+}
+.trl-close:hover { background: rgba(255,255,255,0.18); color: #fff; }
+</style>

--- a/src/views/LessonsOverview.vue
+++ b/src/views/LessonsOverview.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <!-- Source indicator for remote topics -->
-    <div v-if="!isLoading && (isRemote || lessons.length > 0)" class="mb-4 flex items-center justify-between text-sm">
+    <!-- Source indicator (alle Workshops) -->
+    <div v-if="!isLoading && !isLinuxWorkshop && (isRemote || lessons.length > 0)" class="mb-4 flex items-center justify-between text-sm">
       <div>
         <span v-if="workshopDescription" class="text-muted-foreground">{{ workshopDescription }}</span>
         <span v-if="workshopDescription && sourceLabel" class="text-muted-foreground/40 mx-2">·</span>
@@ -25,53 +25,86 @@
       </div>
     </div>
 
-    <!-- Progress bar -->
-    <div id="tour-progress-bar" v-if="!isLoading && lessons.length > 0" class="mb-6">
-      <ProgressBar
-        :completed="completionInfo.completed"
-        :total="completionInfo.total"
-        :label="$t('lesson.completed')" />
-    </div>
+    <!-- ══ ALLE WORKSHOPS: Video-Placeholder + Lektionen im Unit-Frame ══ -->
+    <div v-if="!isLoading && lessons.length > 0" class="unit-frame mb-8">
+      <div class="unit-glow" aria-hidden="true"></div>
 
-    <!-- Learning path -->
-    <div v-if="!isLoading && lessons.length > 0">
-      <LearningPath
-        :lessons="lessons"
-        :next-lesson-number="nextLessonNumber"
-        :favorites="favorites"
-        :get-status="getLessonStatusForPath"
-        :completed-count="completionInfo.completed"
-        :draggable="favorites.length > 1"
-        @reorder="handleReorder">
-        <template #card="{ lesson, status, isFavorite, isNext }">
-          <LessonCard
-            :lesson="lesson"
-            :status="status"
-            :is-favorite="isFavorite"
-            :is-next="isNext"
-            :image-url="resolveLessonImage(lesson)"
-            :answered-count="getAnsweredCount(lesson)"
-            :learned-item-count="getLearnedItemCount(lesson)"
-            :next-label="$t('lesson.continueLabel')"
-            :sections-label="$t('lesson.sections')"
-            :examples-label="$t('lesson.examples')"
-            :quizzes-label="$t('lesson.quizzes')"
-            :audio-label="$t('lesson.audioAvailable')"
-            :video-label="$t('lesson.videoAvailable')"
-            :add-favorite-label="$t('lesson.addFavorite')"
-            :remove-favorite-label="$t('lesson.removeFavorite')"
-            :mark-complete-label="$t('lesson.markComplete')"
-            :mark-incomplete-label="$t('lesson.markIncomplete')"
-            :items-label="$t('lesson.itemsLearned')"
-            @open="openLesson"
-            @toggle-favorite="handleToggleFavorite"
-            @toggle-completed="handleToggleCompleted" />
-        </template>
-      </LearningPath>
+      <WorkshopHeroVideo
+        :title="workshopTitle || 'Linux Grundlagen'"
+        :description="workshopDescription || 'Vom kompletten Anfänger zum sicheren Linux-Bediener — in 10 unterhaltsamen Lektionen, mit Pinguinen.'"
+        :lesson-count="lessons.length"
+        :total-minutes="12"
+        :play-label="isDE ? '▶  Video-Trailer' : '▶  Video Trailer'"
+        :duration-label="isDE ? `${lessons.length} Lektionen` : `${lessons.length} lessons`"
+        :scroll-label="isDE ? 'Lektionen entdecken' : 'Discover lessons'"
+        :workshop-label="workshopTitle"
+        :show-penguin="isLinuxWorkshop"
+        @start="showTrailer = true"
+      />
+
+      <!-- Trailer Modal -->
+      <WorkshopTrailer
+        v-if="showTrailer"
+        :is-d-e="isDE"
+        :workshop-title="workshopTitle"
+        @close="showTrailer = false"
+      />
+
+      <div class="unit-connector">
+        <div class="unit-connector-line"></div>
+        <span class="unit-connector-label">
+          {{ isDE ? `${lessons.length} Lektionen` : `${lessons.length} Lessons` }}
+        </span>
+        <div class="unit-connector-line"></div>
+      </div>
+
+      <div class="unit-lessons">
+        <div id="tour-progress-bar" class="mb-4 px-3 pt-1">
+          <ProgressBar
+            :completed="completionInfo.completed"
+            :total="completionInfo.total"
+            :label="$t('lesson.completed')" />
+        </div>
+        <div class="px-2 pb-4">
+          <LearningPath
+            :lessons="lessons"
+            :next-lesson-number="nextLessonNumber"
+            :favorites="favorites"
+            :get-status="getLessonStatusForPath"
+            :completed-count="completionInfo.completed"
+            :draggable="favorites.length > 1"
+            @reorder="handleReorder">
+            <template #card="{ lesson, status, isFavorite, isNext }">
+              <LessonCard
+                :lesson="lesson"
+                :status="status"
+                :is-favorite="isFavorite"
+                :is-next="isNext"
+                :image-url="resolveLessonImage(lesson)"
+                :answered-count="getAnsweredCount(lesson)"
+                :learned-item-count="getLearnedItemCount(lesson)"
+                :next-label="$t('lesson.continueLabel')"
+                :sections-label="$t('lesson.sections')"
+                :examples-label="$t('lesson.examples')"
+                :quizzes-label="$t('lesson.quizzes')"
+                :audio-label="$t('lesson.audioAvailable')"
+                :video-label="$t('lesson.videoAvailable')"
+                :add-favorite-label="$t('lesson.addFavorite')"
+                :remove-favorite-label="$t('lesson.removeFavorite')"
+                :mark-complete-label="$t('lesson.markComplete')"
+                :mark-incomplete-label="$t('lesson.markIncomplete')"
+                :items-label="$t('lesson.itemsLearned')"
+                @open="openLesson"
+                @toggle-favorite="handleToggleFavorite"
+                @toggle-completed="handleToggleCompleted" />
+            </template>
+          </LearningPath>
+        </div>
+      </div>
     </div>
 
     <!-- Loading state -->
-    <div v-else-if="isLoading" class="text-center py-8">
+    <div v-if="isLoading" class="text-center py-8">
       <div class="text-2xl font-bold text-primary mb-4">
         {{ $t('lesson.loadingLessons') }}
       </div>
@@ -152,6 +185,8 @@ import { formatLangName } from '../utils/formatters'
 import ProgressBar from '@/components/ProgressBar.vue'
 import LessonCard from '@/components/LessonCard.vue'
 import LearningPath from '@/components/LearningPath.vue'
+import WorkshopHeroVideo from '@/components/WorkshopHeroVideo.vue'
+import WorkshopTrailer from '@/components/WorkshopTrailer.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -171,11 +206,18 @@ const { setWorkshopManifest: applyWorkshopManifest, setDefaultManifest } = useMa
 const lessons = ref([])
 const isLoading = ref(true)
 const showIOSInstall = ref(false)
+const showTrailer = ref(false)
 let deferredInstallPrompt = null
 
 const learning = computed(() => route.params.learning)
 const workshop = computed(() => route.params.workshop)
 const isDE = computed(() => learning.value === 'deutsch')
+
+// Linux-Workshop-Erkennung — Hero-Video nur dort zeigen (Platzhalter-Phase)
+const isLinuxWorkshop = computed(() => {
+  const w = (workshop.value || '').toLowerCase()
+  return w.includes('linux')
+})
 const isStandalone = computed(() =>
   window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true
 )
@@ -362,3 +404,81 @@ onUnmounted(() => {
   setDefaultManifest()
 })
 </script>
+
+<style scoped>
+/* ══ Unit-Frame: Video + Lektionen visuell gruppiert ══ */
+.unit-frame {
+  position: relative;
+  border-radius: 22px;
+  overflow: hidden;
+  background: #fff;
+  border: 1px solid rgba(16,185,129,0.18);
+  box-shadow:
+    0 0 0 1px rgba(16,185,129,0.08),
+    0 8px 40px rgba(0,0,0,0.08),
+    0 0 60px rgba(16,185,129,0.06);
+  animation: unit-breathe 5s ease-in-out infinite;
+}
+:global(.dark) .unit-frame {
+  background: #0f1623;
+  border-color: rgba(16,185,129,0.22);
+  box-shadow:
+    0 0 0 1px rgba(16,185,129,0.1),
+    0 8px 40px rgba(0,0,0,0.35),
+    0 0 80px rgba(16,185,129,0.08);
+}
+
+@keyframes unit-breathe {
+  0%, 100% { box-shadow: 0 0 0 1px rgba(16,185,129,0.08), 0 8px 40px rgba(0,0,0,0.08), 0 0 60px rgba(16,185,129,0.06); }
+  50%       { box-shadow: 0 0 0 1px rgba(16,185,129,0.16), 0 8px 40px rgba(0,0,0,0.1),  0 0 90px rgba(16,185,129,0.14); }
+}
+
+/* Animierter Farbverlauf-Rand oben */
+.unit-glow {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, #10b981, #a855f7, #3b82f6, #10b981);
+  background-size: 300% 100%;
+  animation: unit-glow-slide 4s linear infinite;
+  z-index: 10;
+}
+@keyframes unit-glow-slide {
+  0%   { background-position: 0% 0%; }
+  100% { background-position: 300% 0%; }
+}
+
+/* Verbindungs-Divider zwischen Video und Lektionen */
+.unit-connector {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 20px 10px;
+  background: linear-gradient(to bottom, rgba(16,185,129,0.04), transparent);
+}
+:global(.dark) .unit-connector {
+  background: linear-gradient(to bottom, rgba(16,185,129,0.06), transparent);
+}
+.unit-connector-line {
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(16,185,129,0.3), transparent);
+}
+.unit-connector-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #10b981;
+  white-space: nowrap;
+  opacity: 0.8;
+}
+
+/* Lektionen-Bereich */
+.unit-lessons {
+  background: rgba(248,250,252,0.6);
+}
+:global(.dark) .unit-lessons {
+  background: rgba(15,22,35,0.6);
+}
+</style>


### PR DESCRIPTION
## Was

Jeder Workshop bekommt einen visuellen Einstiegsbereich — Video-Hero oben, Lektionsliste darunter, beide als visuelle Einheit gerahmt.

## Neue Komponenten

### `WorkshopHeroVideo.vue`
- Animierter Header: Sternenhimmel, Aurora-Wellen, Berglandschaft
- Tux-Pinguin (Linux only, via `showPenguin`-Prop)
- Touch-Controls: Tap → Play/Pause-Overlay, +15s/-15s, Scrub-Bar
- **Bugfix**: `position: sticky` entfernt — Video blieb beim Scrollen oben hängen und überdeckte Lektionen

### `WorkshopTrailer.vue`
- Filmisches "Coming Soon" Modal (Canvas-Animation, fullscreen)
- Szenen-Sequenz: Workshop-Badge → Titel → Stats (Lektionen/Übungen/Zeit) → "Bald verfügbar"
- Isometrisches 3D-Flat-Design: Terminal-Block mit Tux, schwebende Code-Particles
- CTA-Button schließt Modal und bleibt auf der Übersichtsseite

## Geänderte Dateien

| Datei | Was |
|-------|-----|
| `LessonsOverview.vue` | Unit-Frame für alle Workshops, Trailer-Integration |
| `LessonCard.vue` | Thumbnails auf einheitliche 80×80px fixiert |

## Testen

**Linux-Workshop (Deutsch):**
http://localhost:5173/#/deutsch/local-dev%3Alinux-grundlagen/lessons

1. Seite öffnet → Hero-Video mit Tux sichtbar, keine Sticky-Probleme beim Scrollen
2. Play-Button → Coming-Soon-Trailer öffnet sich als Modal
3. Trailer läuft durch 4 Szenen (~6s), "Jetzt starten" schließt Modal
4. Lektionskarten alle gleich groß, Bilder quadratisch

**Anderer Workshop (ohne Linux):**
5. Hero-Video zeigt — ohne Pinguin, gleiche Aurora/Berge-Animation

Closes #272