### PR TITLE
ux: zentrierter Play-Indikator im Video-Hero (#276)

### DIFF
--- a/specs/video-hero-play-indicator.md
+++ b/specs/video-hero-play-indicator.md
@@ -1,0 +1,24 @@
+# Spec: Video-Hero Play-Indikator
+
+## Problem
+
+Der Workshop-Hero-Bereich sieht aus wie ein dekoratives Banner. Nutzer erkennen erst nach dem Klick, dass es sich um ein interaktives Video-Element handelt.
+
+## Lösung
+
+Zentrierter großer Play-Button mit pulsierender Animation — auf den ersten Blick als Video erkennbar, ohne Erklärung.
+
+## Verhalten
+
+- **Play-Button** ist immer sichtbar in der Mitte des Heroes (nicht unten links)
+- **Puls-Animation**: zwei grüne Ringe die sich nach außen ausdehnen und verblassen (wie YouTube Live-Indikator)
+- **Label** unter dem Button zeigt den `playLabel`-Text (z.B. „Video-Trailer")
+- **Hover**: Button skaliert auf 110 %, Rand wird grün
+- **Nach Klick / Touch-Controls aktiv**: Play-Button blendet sanft aus (Transition), Touch-Controls erscheinen
+- **Der alte grüne Button** unten links entfällt — der zentrierte Button übernimmt die Funktion
+
+## Nicht in diesem Spec
+
+- Echter Video-Player (kommt wenn Video-URLs vorhanden)
+- Fortschrittsbalken am unteren Rand (separates Feature)
+- Trailer-Badge oben rechts (separates Feature)

--- a/src/components/WorkshopHeroVideo.vue
+++ b/src/components/WorkshopHeroVideo.vue
@@ -222,19 +222,39 @@
           {{ description }}
         </p>
         <div class="flex items-center gap-3 flex-wrap">
-          <button
-            @click.stop="$emit('start')"
-            class="flex items-center gap-2 px-6 py-3 bg-emerald-500 hover:bg-emerald-400 text-slate-900 font-bold rounded-xl shadow-lg shadow-emerald-500/30 transition-all hover:scale-105"
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
-            {{ playLabel }}
-          </button>
           <div class="text-sm text-slate-300/80">
             {{ durationLabel }}
           </div>
         </div>
       </div>
     </div>
+
+    <!-- Zentrierter Play-Button (immer sichtbar, verschwindet bei controlsVisible) -->
+    <Transition name="center-play">
+      <div
+        v-if="!controlsVisible"
+        class="absolute inset-0 flex flex-col items-center justify-center pointer-events-none"
+      >
+        <!-- Puls-Ringe -->
+        <div class="relative flex items-center justify-center">
+          <div class="play-pulse-ring" />
+          <div class="play-pulse-ring play-pulse-ring--delay" />
+          <!-- Button -->
+          <button
+            class="play-center-btn pointer-events-auto relative z-10 flex items-center justify-center"
+            @click.stop="$emit('start')"
+          >
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="currentColor" class="ml-1">
+              <path d="M8 5v14l11-7z"/>
+            </svg>
+          </button>
+        </div>
+        <!-- Label unter dem Button -->
+        <span class="mt-3 text-xs font-bold tracking-widest uppercase text-white/70 pointer-events-none select-none">
+          {{ playLabel }}
+        </span>
+      </div>
+    </Transition>
 
     <!-- Hover-Glow Border -->
     <div
@@ -453,6 +473,47 @@ onBeforeUnmount(() => {
   background: linear-gradient(180deg, #0c1b3a 0%, #1e1b4b 100%);
   will-change: transform;
 }
+
+/* ── Zentrierter Play-Button ── */
+.play-center-btn {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.18);
+  border: 2.5px solid rgba(255, 255, 255, 0.55);
+  backdrop-filter: blur(6px);
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.2s, background 0.2s;
+  box-shadow: 0 0 32px rgba(16, 185, 129, 0.35), 0 4px 24px rgba(0,0,0,0.4);
+}
+.play-center-btn:hover {
+  transform: scale(1.1);
+  background: rgba(16, 185, 129, 0.3);
+  border-color: #10b981;
+}
+.play-center-btn:active { transform: scale(0.95); }
+
+/* Puls-Ringe */
+.play-pulse-ring {
+  position: absolute;
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  border: 2px solid rgba(16, 185, 129, 0.5);
+  animation: play-pulse 2.4s ease-out infinite;
+}
+.play-pulse-ring--delay {
+  animation-delay: 1.2s;
+}
+@keyframes play-pulse {
+  0%   { transform: scale(1);    opacity: 0.7; }
+  100% { transform: scale(2.2);  opacity: 0; }
+}
+
+/* Transition für Einblenden/Ausblenden */
+.center-play-enter-active, .center-play-leave-active { transition: opacity 0.25s ease; }
+.center-play-enter-from, .center-play-leave-to { opacity: 0; }
 
 /* Cinema bars */
 .hero-video-container::before,


### PR DESCRIPTION
## Was wurde gemacht

Closes #276

Der Workshop-Hero-Bereich war als dekoratives Banner erkennbar, nicht als Video. Nutzer wussten nicht, dass man klicken kann.

### Änderungen

**`WorkshopHeroVideo.vue`**
- Zentrierter Play-Button (80px, Glasmorphism-Stil) ersetzt den alten grünen Button unten links
- Zwei pulsierende grüne Ringe (`play-pulse-ring`) ziehen die Aufmerksamkeit auf sich
- Button blendet sanft aus wenn Touch-Controls sichtbar sind (`v-if="!controlsVisible"`)
- Hover: Button skaliert auf 110 %, grüner Rand erscheint
- Label unter dem Button (`playLabel` Prop)

**`specs/video-hero-play-indicator.md`** — neue Spec angelegt

## Test

1. http://localhost:5173/#/deutsch/linux-grundlagen/lessons öffnen
2. Großer Play-Button mit pulsierenden Ringen in der Mitte des Heroes sehen
3. Klick → Trailer öffnet sich, Button blendet aus
4. Mobile: Tap → Touch-Controls erscheinen, Play-Button weg