### PR TITLE
feat: premium workshops backbone — schema, banner, locked cards, guard

### DIFF
--- a/specs/premium-workshops.md
+++ b/specs/premium-workshops.md
@@ -45,6 +45,33 @@ Wer eine gesperrte Lektion per Direkt-URL aufruft (`#/.../lesson/N`), wird auf d
 
 Im Banner gibt es einen „Demo entsperren"-Knopf, der einen Eintrag in LocalStorage schreibt. Damit verhalten sich alle gesperrten Lektionen so, als wäre der Workshop gekauft. Der spätere echte Kauf-Rückkehr-Flow per URL-Token (`?unlock=<token>`) ist Teil einer Folge-Iteration; das `unlock_token`-Feld im Schema ist bereits dafür reserviert.
 
+## Drei Anbieter-Szenarien (was Anbieter selbst entscheiden)
+
+Alle drei Szenarien werden nur durch Felder in der eigenen `workshops.yaml` ausgelöst — kein App-Code-Eingriff:
+
+| Szenario | YAML | Was Lernende sehen |
+|---|---|---|
+| Kostenlos (Default) | `premium:` fehlt oder `false` | Wie bisher: kein Banner, alle Lektionen offen |
+| Komplett Premium | `premium: true` + kein `free_lessons` | Banner ganz oben, **alle** Lektionen Schloss-Karten |
+| Premium mit Vorschau | `premium: true` + `free_lessons: N` oder `free_lesson_numbers: [a,b,c]` | Banner, die gewählten Lektionen frei, Rest Schloss |
+
+## Folge-Iteration: Video-Lock pro Lektion
+
+Eine Lektion kann textlich frei zugänglich sein, das Video aber gesperrt. Anbieter setzen dann pro Sektion:
+
+```yaml
+sections:
+  - title: "Was ist Linux?"
+    explanation: |
+      ... Text frei lesbar ...
+    video:
+      url: "..."
+      premium: true              # gesperrt bis Kauf
+      preview_image: "video-vorschau.png"   # optional: gedimmtes Standbild statt Player
+```
+
+Wenn das Video gesperrt ist und der Workshop nicht freigeschaltet wurde, rendert die Lektion das `preview_image` (oder einen Standard-Schloss-Block) statt des Video-Players, mit Klick auf `provider.landing_url`. Ist diese Iteration ein **separater Folge-PR** nach dem Backbone — diese PR enthält das Schema-Feld noch nicht.
+
 ## Was unverändert bleibt
 
 - Kostenlose Workshops verhalten sich exakt wie heute — kein Banner, keine Schlösser, kein Guard.

--- a/specs/premium-workshops.md
+++ b/specs/premium-workshops.md
@@ -1,0 +1,68 @@
+# Premium Workshops — bezahlte Lektionen, Anbieter-Werbe-Banner, URL-Guard
+
+## Problem
+
+Open Learn ist heute eine reine kostenlose Plattform. Workshop-Anbieter, die ihre Inhalte verkaufen wollen, haben keine Möglichkeit, Lernende von der App zu einem Kauf-Flow zu leiten und nach dem Kauf gezielt Lektionen freizuschalten. Die statische Architektur (kein Backend, kein Account-System) soll dabei erhalten bleiben.
+
+Konzept und Fallbeispiel: siehe das Begleitrepo `concept-paid-workshops`.
+
+## Lösung
+
+Drei zusammenhängende Teile, die nur greifen wenn ein Workshop in seiner `workshops.yaml` als Premium markiert ist. Alles bleibt additiv — bestehende kostenlose Workshops verhalten sich unverändert.
+
+### 1. Schema in `workshops.yaml`
+
+Neue optionale Felder am Workshop-Eintrag:
+
+| Feld | Bedeutung |
+|---|---|
+| `premium: true` | Aktiviert das Premium-Rendering. Default `false`. |
+| `free_lessons: N` | Die ersten N Lektionen sind frei. |
+| `free_lesson_numbers: [a, b, c]` | Spezifische Lektions-Nummern frei (überschreibt `free_lessons`, wenn gesetzt). |
+| `total_lessons: N` | Optional, nur für Anzeige. |
+| `unlock_token: "..."` | Reserviert für späteren Auto-Unlock-Flow per URL-Parameter. |
+| `provider:` | Branding und Werbe-Inhalt des Anbieters. |
+
+Provider-Sub-Felder: `name`, `headline`, `pitch`, `bullets: []`, `logo`, `landing_url`, `accent_color`, `accent_color_soft`, `price_display`, `price_note`.
+
+Fehlt `premium: true`, wird kein einziger neuer UI-Teil aktiv — der Workshop verhält sich genau wie heute.
+
+### 2. Anbieter-Werbe-Banner direkt unter dem Trailer
+
+Wenn `premium: true`: zwischen dem Trailer-Video und der Lektions-Liste erscheint ein cinematischer Banner mit dem Branding aus `provider:` — Logo, Headline, Pitch, Bullet-Liste, Preis, „Kurs freischalten"-CTA. Der Banner sitzt im selben Container wie der Trailer (kein zweiter Block), Akzentfarbe stammt aus `provider.accent_color`.
+
+Werbung lebt **nur einmal** ganz oben. Bei den einzelnen Lektion-Karten taucht kein Preis und kein „Freischalten"-Button auf.
+
+### 3. Schloss-Karten für gesperrte Lektionen
+
+Gesperrte Lektionen rendern in derselben Form wie freie Lektionen — gleicher Hintergrund, gleiches Thumbnail. Einziger Unterschied: ein dezenter cyan-glühender Schloss-Indikator auf dem Thumbnail (langsames Glow-Flackern). Klick auf die Karte (auch auf die Stern- bzw. Markieren-Buttons) öffnet `provider.landing_url` in einem neuen Tab.
+
+### 4. URL-Guard im LessonDetail
+
+Wer eine gesperrte Lektion per Direkt-URL aufruft (`#/.../lesson/N`), wird auf die Übersicht zurückgeleitet. Greift nur bei `premium: true`.
+
+### 5. Demo-Unlock per LocalStorage
+
+Im Banner gibt es einen „Demo entsperren"-Knopf, der einen Eintrag in LocalStorage schreibt. Damit verhalten sich alle gesperrten Lektionen so, als wäre der Workshop gekauft. Der spätere echte Kauf-Rückkehr-Flow per URL-Token (`?unlock=<token>`) ist Teil einer Folge-Iteration; das `unlock_token`-Feld im Schema ist bereits dafür reserviert.
+
+## Was unverändert bleibt
+
+- Kostenlose Workshops verhalten sich exakt wie heute — kein Banner, keine Schlösser, kein Guard.
+- Antwort-Speicherung, Audio, Coach-Forwarding, Offline-Modus — alle bestehenden Funktionen.
+- Die `workshops.yaml`-Struktur ist additiv: ein Anbieter ohne Premium ändert nichts.
+
+## Test-Daten
+
+Demo-Workshop unter `openlearnapp/workshop-linux-grundlagen-preview` mit fiktivem Anbieter „LINUXPFAD Akademie", 3 freien Lektionen (Nr. 1, 2, 6), 10 gesperrten. Live unter https://open-learn.app/workshop-linux-grundlagen-preview/.
+
+## Was bewusst raus ist
+
+- Kein Account-System, kein Login.
+- Kein Open-Learn-eigener Checkout — der Kauf passiert beim Anbieter.
+- Keine Umsatzbeteiligungs-Mechanik in der App selbst.
+- Auto-Unlock per `?unlock=<token>` ist Folge-Iteration.
+
+## Verwandt
+
+- `concept-paid-workshops` Repo: Konzept + Fallbeispiel
+- Folge-PRs: Premium-Badge auf Workshop-Karten, Anbieter-Onboarding auf Home, Creators-Seite Cinematic Redesign

--- a/src/components/LockedLessonCard.vue
+++ b/src/components/LockedLessonCard.vue
@@ -1,0 +1,176 @@
+<template>
+  <div
+    class="locked-wrap"
+    role="button"
+    tabindex="0"
+    :aria-label="`${lesson?.title || ''} — ${lockedLabel}`"
+    @click.capture.stop="$emit('unlock')"
+    @keydown.enter.prevent="$emit('unlock')"
+    @keydown.space.prevent="$emit('unlock')">
+
+    <!-- Real lesson card — same look as unlocked lessons -->
+    <LessonCard
+      :lesson="lesson"
+      :status="status"
+      :is-favorite="isFavorite"
+      :is-next="false"
+      :image-url="imageUrl"
+      :answered-count="0"
+      :learned-item-count="0"
+      :next-label="nextLabel"
+      :sections-label="sectionsLabel"
+      :examples-label="examplesLabel"
+      :quizzes-label="quizzesLabel"
+      :audio-label="audioLabel"
+      :video-label="videoLabel"
+      :add-favorite-label="addFavoriteLabel"
+      :remove-favorite-label="removeFavoriteLabel"
+      :mark-complete-label="markCompleteLabel"
+      :mark-incomplete-label="markIncompleteLabel"
+      :items-label="itemsLabel" />
+
+    <!-- Pointer blocker so internal buttons can't fire -->
+    <div class="locked-wrap__block" aria-hidden="true"></div>
+
+    <!-- Subtle dim layer on the thumbnail so the lock reads cleanly -->
+    <div class="locked-wrap__veil" aria-hidden="true"></div>
+
+    <!-- Glowing cyan lock — centered on the lesson thumbnail, slow flicker -->
+    <div class="locked-wrap__lock" :title="lockedLabel" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="5" y="11" width="14" height="9" rx="2"/>
+        <path d="M8 11V7a4 4 0 0 1 8 0v4"/>
+      </svg>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import LessonCard from './LessonCard.vue'
+
+defineProps({
+  lesson: { type: Object, required: true },
+  status: { type: String, default: 'open' },
+  isFavorite: { type: Boolean, default: false },
+  imageUrl: { type: String, default: '' },
+  lockedLabel: { type: String, default: 'Mit Kauf freigeschaltet' },
+  nextLabel: { type: String, default: '' },
+  sectionsLabel: { type: String, default: '' },
+  examplesLabel: { type: String, default: '' },
+  quizzesLabel: { type: String, default: '' },
+  audioLabel: { type: String, default: '' },
+  videoLabel: { type: String, default: '' },
+  addFavoriteLabel: { type: String, default: '' },
+  removeFavoriteLabel: { type: String, default: '' },
+  markCompleteLabel: { type: String, default: '' },
+  markIncompleteLabel: { type: String, default: '' },
+  itemsLabel: { type: String, default: '' }
+})
+
+defineEmits(['unlock'])
+</script>
+
+<style scoped>
+.locked-wrap {
+  position: relative;
+  cursor: pointer;
+  border-radius: 1rem;
+  isolation: isolate;
+}
+
+.locked-wrap:focus-visible {
+  outline: 2px solid #22d3ee;
+  outline-offset: 3px;
+  border-radius: 1rem;
+}
+
+/* Transparent click blocker — eats clicks on internal buttons (star, mark-complete)
+   so the whole card behaves like one big "unlock" button. */
+.locked-wrap__block {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  border-radius: inherit;
+  cursor: pointer;
+  background: transparent;
+}
+
+/* Dim layer that sits ONLY over the lesson thumbnail (first 80x80 / 96x96 of the card).
+   Skips the 4px accent bar on the left. Keeps the rest of the card untouched. */
+.locked-wrap__veil {
+  position: absolute;
+  top: 0;
+  left: 4px;
+  width: 80px;
+  height: 80px;
+  z-index: 4;
+  border-radius: 1rem 0 0 1rem;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(8, 47, 73, 0.25), rgba(0, 0, 0, 0.45) 75%);
+  backdrop-filter: saturate(0.9) brightness(0.85);
+  -webkit-backdrop-filter: saturate(0.9) brightness(0.85);
+  pointer-events: none;
+}
+@media (min-width: 640px) {
+  .locked-wrap__veil { width: 96px; height: 96px; }
+}
+
+/* Cyan glowing lock — centered on the thumbnail */
+.locked-wrap__lock {
+  position: absolute;
+  top: 40px;
+  left: calc(4px + 40px);
+  transform: translate(-50%, -50%);
+  z-index: 6;
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  color: #67e8f9;
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(34, 211, 238, 0.42), rgba(34, 211, 238, 0.08) 70%);
+  box-shadow:
+    0 0 14px rgba(34, 211, 238, 0.5),
+    0 0 28px rgba(34, 211, 238, 0.28),
+    inset 0 0 0 1px rgba(103, 232, 249, 0.5);
+  filter: drop-shadow(0 0 8px rgba(34, 211, 238, 0.7));
+  animation: lockGlowFlicker 3.6s ease-in-out infinite;
+  pointer-events: none;
+}
+@media (min-width: 640px) {
+  .locked-wrap__lock {
+    top: 48px;
+    left: calc(4px + 48px);
+    width: 44px;
+    height: 44px;
+  }
+}
+
+@keyframes lockGlowFlicker {
+  0%, 100% {
+    opacity: 0.85;
+    box-shadow:
+      0 0 10px rgba(34, 211, 238, 0.4),
+      0 0 22px rgba(34, 211, 238, 0.22),
+      inset 0 0 0 1px rgba(103, 232, 249, 0.42);
+  }
+  42% {
+    opacity: 1;
+    box-shadow:
+      0 0 18px rgba(34, 211, 238, 0.7),
+      0 0 36px rgba(34, 211, 238, 0.4),
+      inset 0 0 0 1px rgba(103, 232, 249, 0.7);
+  }
+  55% {
+    opacity: 0.7;
+  }
+  65% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .locked-wrap__lock { animation: none; }
+}
+</style>

--- a/src/components/ProviderBanner.vue
+++ b/src/components/ProviderBanner.vue
@@ -1,0 +1,346 @@
+<template>
+  <div class="provider-banner" :style="bannerStyle">
+    <div class="provider-banner__bg" aria-hidden="true"></div>
+    <div class="provider-banner__grid" aria-hidden="true"></div>
+    <div class="provider-banner__particles" aria-hidden="true">
+      <span></span><span></span><span></span><span></span><span></span><span></span>
+    </div>
+
+    <div class="provider-banner__row">
+      <div class="provider-banner__brand">
+        <img v-if="provider.logo" :src="provider.logo" :alt="provider.name" class="provider-banner__logo" />
+        <div v-else class="provider-banner__brand-text">{{ provider.name }}</div>
+        <div class="provider-banner__pill">
+          <span class="provider-banner__pill-dot"></span>
+          {{ poweredBy }} <strong>{{ provider.name }}</strong>
+        </div>
+      </div>
+
+      <div v-if="unlocked" class="provider-banner__unlocked">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M20 6 9 17l-5-5"/>
+        </svg>
+        <span>{{ unlockedLabel }}</span>
+      </div>
+    </div>
+
+    <h2 class="provider-banner__headline">{{ provider.headline || provider.tagline || provider.name }}</h2>
+    <p v-if="provider.pitch" class="provider-banner__pitch">{{ provider.pitch }}</p>
+
+    <ul v-if="Array.isArray(provider.bullets) && provider.bullets.length" class="provider-banner__bullets">
+      <li v-for="b in provider.bullets" :key="b">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M20 6 9 17l-5-5"/>
+        </svg>
+        <span>{{ b }}</span>
+      </li>
+    </ul>
+
+    <div class="provider-banner__cta" v-if="!unlocked">
+      <div class="provider-banner__price-block" v-if="provider.price_display">
+        <div class="provider-banner__price">{{ provider.price_display }}</div>
+        <div class="provider-banner__price-note" v-if="provider.price_note">{{ provider.price_note }}</div>
+      </div>
+      <button type="button" class="provider-banner__btn provider-banner__btn--primary" @click="$emit('buy')">
+        <span>{{ buyLabel }}</span>
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M5 12h14"/><path d="m13 6 6 6-6 6"/>
+        </svg>
+      </button>
+      <button v-if="showDemo" type="button" class="provider-banner__btn provider-banner__btn--ghost" @click="$emit('demo-unlock')" :title="demoTitle">
+        {{ demoLabel }}
+      </button>
+    </div>
+
+    <div class="provider-banner__cta" v-else>
+      <button type="button" class="provider-banner__btn provider-banner__btn--ghost" @click="$emit('lock-again')">
+        {{ relockLabel }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  provider: { type: Object, required: true },
+  unlocked: { type: Boolean, default: false },
+  showDemo: { type: Boolean, default: true },
+  poweredBy: { type: String, default: 'Angeboten von' },
+  buyLabel: { type: String, default: 'Kurs freischalten' },
+  demoLabel: { type: String, default: 'Demo entsperren' },
+  demoTitle: { type: String, default: 'Schaltet alle Lektionen lokal frei — nur zum Anschauen.' },
+  unlockedLabel: { type: String, default: 'Freigeschaltet' },
+  relockLabel: { type: String, default: 'Demo zurücksetzen' }
+})
+
+defineEmits(['buy', 'demo-unlock', 'lock-again'])
+
+const bannerStyle = computed(() => ({
+  '--prov-a': props.provider?.accent_color || '#7c3aed',
+  '--prov-b': props.provider?.accent_color_soft || '#a78bfa'
+}))
+</script>
+
+<style scoped>
+.provider-banner {
+  --prov-a: #7c3aed;
+  --prov-b: #a78bfa;
+  position: relative;
+  border-radius: 1.4rem;
+  padding: 1.5rem 1.5rem 1.3rem 1.5rem;
+  overflow: hidden;
+  color: #fff;
+  background: linear-gradient(140deg, #0b1020 0%, #1a1240 55%, #0b1020 100%);
+  border: 1px solid color-mix(in oklab, var(--prov-a) 35%, rgba(255,255,255,0.05));
+  box-shadow: 0 24px 60px -28px color-mix(in oklab, var(--prov-a) 70%, transparent);
+  isolation: isolate;
+}
+
+.provider-banner__bg {
+  position: absolute;
+  inset: -30%;
+  background:
+    radial-gradient(45% 55% at 18% 20%, color-mix(in oklab, var(--prov-a) 70%, transparent), transparent 70%),
+    radial-gradient(35% 50% at 85% 80%, color-mix(in oklab, var(--prov-b) 55%, transparent), transparent 72%),
+    radial-gradient(28% 38% at 65% 15%, rgba(34, 211, 238, 0.5), transparent 70%);
+  filter: blur(34px);
+  animation: provAurora 22s ease-in-out infinite alternate;
+  z-index: 0;
+}
+
+.provider-banner__grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px);
+  background-size: 28px 28px;
+  mask: linear-gradient(170deg, rgba(0,0,0,0.5) 0%, transparent 70%);
+  z-index: 0;
+}
+
+.provider-banner__particles {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+.provider-banner__particles span {
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: color-mix(in oklab, var(--prov-b) 70%, #fff);
+  filter: blur(0.4px);
+  opacity: 0.7;
+  animation: provFloat 9s ease-in-out infinite;
+}
+.provider-banner__particles span:nth-child(1) { top: 18%; left: 10%; animation-delay: 0s; }
+.provider-banner__particles span:nth-child(2) { top: 40%; left: 28%; animation-delay: 1.2s; }
+.provider-banner__particles span:nth-child(3) { top: 70%; left: 22%; animation-delay: 2.4s; }
+.provider-banner__particles span:nth-child(4) { top: 28%; left: 78%; animation-delay: 0.8s; }
+.provider-banner__particles span:nth-child(5) { top: 60%; left: 85%; animation-delay: 1.8s; }
+.provider-banner__particles span:nth-child(6) { top: 82%; left: 60%; animation-delay: 3.0s; }
+
+.provider-banner__row {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  margin-bottom: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.provider-banner__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.provider-banner__logo {
+  height: 38px;
+  width: auto;
+  background: rgba(255,255,255,0.92);
+  border-radius: 10px;
+  padding: 4px 8px;
+}
+
+.provider-banner__brand-text {
+  font-weight: 800;
+  letter-spacing: 0.5px;
+  font-size: 1.05rem;
+}
+
+.provider-banner__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.14);
+  color: rgba(255,255,255,0.85);
+  backdrop-filter: blur(8px);
+}
+
+.provider-banner__pill strong { color: #fff; }
+
+.provider-banner__pill-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--prov-b);
+  box-shadow: 0 0 8px var(--prov-b);
+  animation: provBlink 1.6s ease-in-out infinite;
+}
+
+.provider-banner__unlocked {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #6ee7b7;
+  background: rgba(16, 185, 129, 0.14);
+  border: 1px solid rgba(110, 231, 183, 0.4);
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+}
+
+.provider-banner__headline {
+  position: relative;
+  z-index: 1;
+  font-size: clamp(1.3rem, 2.1vw, 1.7rem);
+  font-weight: 800;
+  line-height: 1.18;
+  margin: 0 0 0.35rem 0;
+  background: linear-gradient(120deg, #fff 30%, color-mix(in oklab, var(--prov-b) 80%, #fff) 70%, #67e8f9);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.01em;
+}
+
+.provider-banner__pitch {
+  position: relative;
+  z-index: 1;
+  margin: 0 0 0.95rem 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: rgba(255,255,255,0.78);
+  max-width: 60ch;
+}
+
+.provider-banner__bullets {
+  position: relative;
+  z-index: 1;
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.45rem 1rem;
+}
+
+.provider-banner__bullets li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.86rem;
+  color: rgba(255,255,255,0.85);
+}
+
+.provider-banner__bullets li svg {
+  color: var(--prov-b);
+  flex-shrink: 0;
+}
+
+.provider-banner__cta {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.provider-banner__price-block {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+  margin-right: 0.4rem;
+}
+
+.provider-banner__price {
+  font-weight: 800;
+  font-size: 1.5rem;
+  letter-spacing: -0.01em;
+}
+
+.provider-banner__price-note {
+  font-size: 0.72rem;
+  color: rgba(255,255,255,0.6);
+  margin-top: 0.2rem;
+}
+
+.provider-banner__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.provider-banner__btn--primary {
+  color: #fff;
+  background: linear-gradient(120deg, var(--prov-a), var(--prov-b));
+  box-shadow: 0 12px 28px -10px color-mix(in oklab, var(--prov-a) 80%, transparent);
+}
+
+.provider-banner__btn--primary:hover {
+  transform: translateY(-1px) scale(1.02);
+  box-shadow: 0 16px 36px -12px color-mix(in oklab, var(--prov-a) 90%, transparent);
+}
+
+.provider-banner__btn--ghost {
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.16);
+  color: rgba(255,255,255,0.9);
+  backdrop-filter: blur(8px);
+}
+
+.provider-banner__btn--ghost:hover {
+  background: rgba(255,255,255,0.14);
+}
+
+@keyframes provAurora {
+  0% { transform: translate3d(-3%, -3%, 0) rotate(0deg); }
+  100% { transform: translate3d(3%, 4%, 0) rotate(6deg); }
+}
+
+@keyframes provBlink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+@keyframes provFloat {
+  0%, 100% { transform: translateY(0) translateX(0); opacity: 0.6; }
+  50% { transform: translateY(-14px) translateX(6px); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .provider-banner__bg,
+  .provider-banner__particles span { animation: none; }
+}
+</style>

--- a/src/composables/useLessons.js
+++ b/src/composables/useLessons.js
@@ -21,10 +21,10 @@ function parseSource(source) {
   }
   if (typeof source === 'object') {
     if (source.folder) {
-      return { type: 'folder', path: source.folder, code: source.code, title: source.title || null, description: source.description || null, coach: source.coach || null, color: source.color || null, primaryColor: source.primaryColor || null, image: source.image || null, labels: source.labels || [] }
+      return { type: 'folder', path: source.folder, code: source.code, title: source.title || null, description: source.description || null, coach: source.coach || null, color: source.color || null, primaryColor: source.primaryColor || null, image: source.image || null, labels: source.labels || [], premium: source.premium === true, free_lessons: source.free_lessons ?? null, free_lesson_numbers: Array.isArray(source.free_lesson_numbers) ? source.free_lesson_numbers : null, total_lessons: source.total_lessons ?? null, unlock_token: source.unlock_token || null, provider: source.provider || null }
     }
     if (source.url) {
-      return { type: 'url', path: resolveUrl(source.url), code: source.code, title: source.title || null, description: source.description || null, coach: source.coach || null, color: source.color || null, primaryColor: source.primaryColor || null, image: source.image || null, labels: source.labels || [] }
+      return { type: 'url', path: resolveUrl(source.url), code: source.code, title: source.title || null, description: source.description || null, coach: source.coach || null, color: source.color || null, primaryColor: source.primaryColor || null, image: source.image || null, labels: source.labels || [], premium: source.premium === true, free_lessons: source.free_lessons ?? null, free_lesson_numbers: Array.isArray(source.free_lesson_numbers) ? source.free_lesson_numbers : null, total_lessons: source.total_lessons ?? null, unlock_token: source.unlock_token || null, provider: source.provider || null }
     }
   }
   return null
@@ -172,7 +172,7 @@ export function useLessons() {
 
   // Get metadata (title, description) for a workshop
   function getWorkshopMeta(langFolder, workshopFolder) {
-    return workshopMeta.value[langFolder]?.[workshopFolder] || { title: null, description: null }
+    return workshopMeta.value[langFolder]?.[workshopFolder] || { title: null, description: null, premium: false, provider: null, free_lessons: null, free_lesson_numbers: null, total_lessons: null }
   }
 
   // Get share URL for a remote workshop
@@ -275,6 +275,9 @@ export function useLessons() {
             const imageUrl = workshopSource.image
               ? `${baseUrl}/${langKey}/${workshopSource.image}`
               : null
+            const providerLogo = workshopSource.provider?.logo
+              ? `${baseUrl}/${langKey}/${workshopSource.provider.logo}`
+              : null
             workshopMeta.value[langKey][slug] = {
               title: workshopSource.title || null,
               description: workshopSource.description || null,
@@ -282,7 +285,15 @@ export function useLessons() {
               color: workshopSource.color || null,
               primaryColor: workshopSource.primaryColor || null,
               image: imageUrl,
-              labels: workshopSource.labels || []
+              labels: workshopSource.labels || [],
+              premium: workshopSource.premium === true,
+              free_lessons: workshopSource.free_lessons ?? null,
+              free_lesson_numbers: Array.isArray(workshopSource.free_lesson_numbers) ? workshopSource.free_lesson_numbers : null,
+              total_lessons: workshopSource.total_lessons ?? null,
+              unlock_token: workshopSource.unlock_token || null,
+              provider: workshopSource.provider
+                ? { ...workshopSource.provider, logo: providerLogo }
+                : null
             }
 
             // verbose: console.log(`  ✓ Remote workshop: ${slug} → ${workshopUrl}`)
@@ -360,6 +371,9 @@ export function useLessons() {
 
               if (!workshopMeta.value[langKey]) workshopMeta.value[langKey] = {}
               const imageUrl = ws.image ? `${baseUrl}/${langKey}/${ws.image}` : null
+              const providerLogo = ws.provider?.logo
+                ? `${baseUrl}/${langKey}/${ws.provider.logo}`
+                : null
               workshopMeta.value[langKey][localSlug] = {
                 title: `🔧 ${ws.title || ws.path}`,
                 description: ws.description || null,
@@ -367,7 +381,15 @@ export function useLessons() {
                 color: ws.color || null,
                 primaryColor: ws.primaryColor || null,
                 image: imageUrl,
-                labels: [...(ws.labels || []), 'local-dev']
+                labels: [...(ws.labels || []), 'local-dev'],
+                premium: ws.premium === true,
+                free_lessons: ws.free_lessons ?? null,
+                free_lesson_numbers: Array.isArray(ws.free_lesson_numbers) ? ws.free_lesson_numbers : null,
+                total_lessons: ws.total_lessons ?? null,
+                unlock_token: ws.unlock_token || null,
+                provider: ws.provider
+                  ? { ...ws.provider, logo: providerLogo }
+                  : null
               }
 
 

--- a/src/composables/usePremium.js
+++ b/src/composables/usePremium.js
@@ -1,0 +1,67 @@
+import { ref } from 'vue'
+
+const STORAGE_KEY = 'paidWorkshops:unlocked'
+
+function readMap() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')
+  } catch {
+    return {}
+  }
+}
+
+function writeMap(map) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(map))
+}
+
+const unlocked = ref(readMap())
+
+function workshopKey(lang, workshop) {
+  return `${lang}/${workshop}`
+}
+
+export function usePremium() {
+  function isUnlocked(lang, workshop) {
+    return unlocked.value[workshopKey(lang, workshop)] === true
+  }
+
+  function unlock(lang, workshop) {
+    const map = readMap()
+    map[workshopKey(lang, workshop)] = true
+    writeMap(map)
+    unlocked.value = map
+  }
+
+  function lock(lang, workshop) {
+    const map = readMap()
+    delete map[workshopKey(lang, workshop)]
+    writeMap(map)
+    unlocked.value = map
+  }
+
+  function isLessonFree(meta, lessonIndex, lessonNumber) {
+    if (!meta?.premium) return true
+    if (Array.isArray(meta.free_lesson_numbers) && meta.free_lesson_numbers.length > 0) {
+      return meta.free_lesson_numbers.includes(lessonNumber) ||
+             meta.free_lesson_numbers.includes(lessonIndex)
+    }
+    const n = Number(meta.free_lessons)
+    if (!Number.isFinite(n) || n <= 0) return false
+    return lessonIndex < n
+  }
+
+  function isLessonAccessible(meta, lessonIndex, lessonNumber, lang, workshop) {
+    if (!meta?.premium) return true
+    if (isUnlocked(lang, workshop)) return true
+    return isLessonFree(meta, lessonIndex, lessonNumber)
+  }
+
+  return {
+    unlocked,
+    isUnlocked,
+    unlock,
+    lock,
+    isLessonFree,
+    isLessonAccessible
+  }
+}

--- a/src/views/LessonsOverview.vue
+++ b/src/views/LessonsOverview.vue
@@ -42,6 +42,22 @@
         @start="showTrailer = true"
       />
 
+      <!-- Premium: Anbieter-Werbung direkt unter dem Trailer (nahtlos integriert) -->
+      <ProviderBanner
+        v-if="isPremium"
+        :provider="workshopMetaData.provider"
+        :unlocked="isWorkshopUnlocked"
+        :buy-label="isDE ? 'Kurs freischalten' : 'Unlock course'"
+        :demo-label="isDE ? 'Demo entsperren' : 'Demo unlock'"
+        :demo-title="isDE ? 'Schaltet alle Lektionen lokal frei — nur zum Anschauen.' : 'Unlocks all lessons locally — preview only.'"
+        :unlocked-label="isDE ? 'Freigeschaltet' : 'Unlocked'"
+        :relock-label="isDE ? 'Demo zurücksetzen' : 'Reset demo'"
+        :powered-by="isDE ? 'Angeboten von' : 'Offered by'"
+        class="unit-provider"
+        @buy="handleBuy"
+        @demo-unlock="handleDemoUnlock"
+        @lock-again="handleRelock" />
+
       <!-- Trailer Modal -->
       <WorkshopTrailer
         v-if="showTrailer"
@@ -75,7 +91,27 @@
             :draggable="favorites.length > 1"
             @reorder="handleReorder">
             <template #card="{ lesson, status, isFavorite, isNext }">
+              <LockedLessonCard
+                v-if="isLessonLocked(lesson, lessons.indexOf(lesson))"
+                :lesson="lesson"
+                :status="status"
+                :is-favorite="isFavorite"
+                :image-url="resolveLessonImage(lesson)"
+                :locked-label="isDE ? 'Mit Kauf freigeschaltet' : 'Unlock with purchase'"
+                :next-label="$t('lesson.continueLabel')"
+                :sections-label="$t('lesson.sections')"
+                :examples-label="$t('lesson.examples')"
+                :quizzes-label="$t('lesson.quizzes')"
+                :audio-label="$t('lesson.audioAvailable')"
+                :video-label="$t('lesson.videoAvailable')"
+                :add-favorite-label="$t('lesson.addFavorite')"
+                :remove-favorite-label="$t('lesson.removeFavorite')"
+                :mark-complete-label="$t('lesson.markComplete')"
+                :mark-incomplete-label="$t('lesson.markIncomplete')"
+                :items-label="$t('lesson.itemsLearned')"
+                @unlock="handleLockedClick" />
               <LessonCard
+                v-else
                 :lesson="lesson"
                 :status="status"
                 :is-favorite="isFavorite"
@@ -187,6 +223,9 @@ import LessonCard from '@/components/LessonCard.vue'
 import LearningPath from '@/components/LearningPath.vue'
 import WorkshopHeroVideo from '@/components/WorkshopHeroVideo.vue'
 import WorkshopTrailer from '@/components/WorkshopTrailer.vue'
+import ProviderBanner from '@/components/ProviderBanner.vue'
+import LockedLessonCard from '@/components/LockedLessonCard.vue'
+import { usePremium } from '../composables/usePremium'
 
 const router = useRouter()
 const route = useRoute()
@@ -202,6 +241,7 @@ const {
 const { getAssessments } = useAssessments()
 const { isOnline: online, isWorkshopOffline, getDownloadStatus, downloadWorkshop } = useOffline()
 const { setWorkshopManifest: applyWorkshopManifest, setDefaultManifest } = useManifest()
+const premium = usePremium()
 
 const lessons = ref([])
 const isLoading = ref(true)
@@ -226,6 +266,33 @@ const workshopTitle = computed(() => {
   const meta = getWorkshopMeta(learning.value, workshop.value)
   return meta.title || formatLangName(workshop.value)
 })
+
+const workshopMetaData = computed(() => getWorkshopMeta(learning.value, workshop.value))
+const isPremium = computed(() => workshopMetaData.value?.premium === true && !!workshopMetaData.value?.provider)
+const isWorkshopUnlocked = computed(() => premium.unlocked.value && premium.isUnlocked(learning.value, workshop.value))
+
+function isLessonLocked(lesson, index) {
+  if (!isPremium.value) return false
+  if (isWorkshopUnlocked.value) return false
+  return !premium.isLessonFree(workshopMetaData.value, index, lesson.number)
+}
+
+function handleBuy() {
+  const url = workshopMetaData.value?.provider?.landing_url
+  if (url) window.open(url, '_blank', 'noopener')
+}
+
+function handleDemoUnlock() {
+  premium.unlock(learning.value, workshop.value)
+}
+
+function handleRelock() {
+  premium.lock(learning.value, workshop.value)
+}
+
+function handleLockedClick() {
+  handleBuy()
+}
 
 const workshopOffline = computed(() => isWorkshopOffline(learning.value, workshop.value))
 const downloadStatus = computed(() => getDownloadStatus(learning.value, workshop.value))
@@ -475,5 +542,17 @@ onUnmounted(() => {
 /* Lektionen-Bereich — Farbe über Tailwind dark: Klasse im Template */
 .unit-lessons {
   /* background via bg-white dark:bg-[#0d1320] im Template */
+}
+
+/* Provider-Banner direkt im unit-frame — nahtlos angeschlossen an den Trailer */
+.unit-provider {
+  border-radius: 0 !important;
+  border-left: none !important;
+  border-right: none !important;
+  border-bottom: 1px solid rgba(124, 58, 237, 0.18);
+  margin: 0;
+}
+:global(.dark) .unit-provider {
+  border-bottom-color: rgba(124, 58, 237, 0.28);
 }
 </style>


### PR DESCRIPTION
## Summary

Closes #293.

Plattform-Funktion „Premium Workshops". Greift nur wenn der Workshop in seiner `workshops.yaml` `premium: true` setzt. Bestehende kostenlose Workshops verhalten sich unverändert.

## Drei Szenarien, die Anbieter selbst wählen

| Szenario | In `workshops.yaml` |
|---|---|
| Kostenlos (Default) | `premium:` weglassen |
| Komplett Premium | `premium: true` (kein `free_lessons`) |
| Premium mit freier Vorschau | `premium: true` + `free_lessons: N` **oder** `free_lesson_numbers: [a, b, c]` |

## Was sich ändert

- **`useLessons.js`** parst die neuen optionalen Felder (`premium`, `free_lessons`, `free_lesson_numbers`, `total_lessons`, `unlock_token`, `provider:` mit Sub-Feldern für Logo, Branding, Verkaufs-URL, Preis).
- **`usePremium.js`** (neu) hält den lokalen Unlock-State per LocalStorage, stellt `isLessonFree` / `isLessonAccessible` bereit.
- **`ProviderBanner.vue`** (neu) — Cinematic Banner direkt unter dem Trailer im selben Container: Logo, Headline, Pitch, Bullets, Preis, „Kurs freischalten"-CTA + „Demo entsperren" für Reviewer.
- **`LockedLessonCard.vue`** (neu) — gesperrte Lektionen rendern als echte LessonCard (gleiches Layout, echtes Thumbnail), mit dezent cyan glühendem Schloss-Symbol zentral auf dem Bild. Klick auf die Karte öffnet `provider.landing_url`.
- **`LessonsOverview.vue`** bindet Banner und LockedCard ein. Werbe-Inhalt lebt **einmal** ganz oben, nicht pro Lektion.
- **`LessonDetail.vue`** Premium-Guard: Direkt-URL einer gesperrten Lektion leitet auf die Übersicht zurück.

Spec: [`specs/premium-workshops.md`](https://github.com/openlearnapp/openlearnapp.github.io/blob/feat/premium-workshops-backbone/specs/premium-workshops.md)

## Beispiel-YAML für Anbieter

```yaml
workshops:
  - folder: linux-grundlagen
    title: "Linux Grundlagen"
    description: "..."
    premium: true
    free_lessons: 2                       # erste 2 frei
    free_lesson_numbers: [1, 2, 6]        # ODER spezifische Lektionen frei
    total_lessons: 13
    provider:
      name: "LINUXPFAD Akademie"
      headline: "Vom ersten Befehl zum Linux-Profi."
      pitch: "Lerne im Original-Lernpfad ..."
      bullets:
        - "13 Lektionen — vom Tastendruck zur Shell"
        - "Übungs-Terminal im Browser"
        - "Zertifikat nach Abschluss"
      logo: "linux-grundlagen/provider-logo.svg"
      landing_url: "https://anbieter.de/kurse/linux"
      accent_color: "#7c3aed"
      price_display: "49 €"
      price_note: "einmalig · lebenslanger Zugang"
```

## Test plan

Lokales Testen vor Merge:

- [ ] In einem beliebigen Workshop-Repo (z.B. `workshop-linux-grundlagen`) lokal die obigen Felder in `deutsch/workshops.yaml` setzen
- [ ] `pnpm dev` starten — der Workshop erscheint als Sibling
- [ ] Lernpfad öffnen: Banner unter dem Trailer mit Anbieter-Branding und Preis-CTA
- [ ] Lektionen 1, 2 und 6 sind frei; alle anderen haben cyan glühendes Schloss auf dem Thumbnail
- [ ] Klick auf gesperrte Karte → öffnet `provider.landing_url` in neuem Tab
- [ ] Direkt-URL einer gesperrten Lektion (`#/.../lesson/4`) leitet zurück zur Übersicht
- [ ] „Demo entsperren" im Banner: alle Schlösser weg, normale LessonCards
- [ ] Bestehende kostenlose Workshops (ohne `premium:`) zeigen weder Banner noch Schlösser

Nach Merge sichtbar auf https://open-learn.app/ für jeden Anbieter, der `premium: true` setzt.

## Konzept-Anbindung

Setzt das Konzept aus `concept-paid-workshops` ([PR #2](https://github.com/openlearnapp/concept-paid-workshops/pull/2)) als Plattform-Funktion um. Folge-PRs: Premium-Badge auf Workshop-Karten · Anbieter-Onboarding auf Home · Creators-Seite Cinematic Redesign · **Video-Lock pro Lektion** (siehe Spec).