### PR TITLE
feat: premium badge + aurora border on workshop cards

### DIFF
--- a/specs/premium-badge-on-workshop-cards.md
+++ b/specs/premium-badge-on-workshop-cards.md
@@ -1,0 +1,36 @@
+# Premium-Indikator auf Workshop-Karten
+
+## Problem
+
+Heute gibt es in der Workshop-Liste (`/#/deutsch`) keinen visuellen Unterschied zwischen kostenlosen und bezahlten Workshops. Lernende erkennen Premium-Workshops erst, wenn sie reinklicken und den Anbieter-Banner sehen. Anbieter-Branding und Preis bleiben unsichtbar in der Discovery-Phase.
+
+## Lösung
+
+Workshop-Karten mit `premium: true` bekommen drei klare Premium-Signale, die direkt auf der Karte sitzen:
+
+### 1. Premium-Badge
+Animiertes Aurora-Sternchen-Badge in der oberen rechten Ecke der Karte. Akzentfarbe stammt aus `provider.accent_color`. Wenn der Workshop für den Lernenden bereits freigeschaltet ist (LocalStorage), zeigt das Badge „Freigeschaltet" statt „Premium".
+
+### 2. Aurora-Rand um die Karte
+Animierter Farbverlauf-Rand (cyan → violett → cyan) um die ganze Workshop-Karte. Dezent, läuft langsam, springt nicht ins Auge — aber genug, dass die Karte sich von kostenlosen Workshops unterscheidet.
+
+### 3. Anbieter-Strip am Karten-Fuß
+Unter Titel und Beschreibung erscheint eine kleine Zeile:
+- links: „Angeboten von **\<Anbieter-Name\>**"
+- rechts: Preis aus `provider.price_display` in Anbieter-Akzentfarbe
+
+Wenn der Workshop freigeschaltet ist, fällt der Preis weg.
+
+## Was unverändert bleibt
+
+- Kostenlose Workshops bekommen keinen Aurora-Rand, kein Badge, keinen Anbieter-Strip
+- Karten-Layout, Bilder, Labels, Favoriten-Knopf, Link-Kopieren — alles bleibt wie heute
+- Workshop-Card-Click führt weiterhin in die Lessons-Overview (von dort Provider-Banner + Schloss-Karten aus PR #294)
+
+## Abhängigkeit
+
+Setzt PR #294 (Premium-Backbone) voraus — nutzt das durchgereichte `meta.provider` und `meta.premium` aus `useLessons`.
+
+## Test-Daten
+
+Jeder Workshop mit `premium: true` in `workshops.yaml`. Beispiel-YAML im PR-Body.

--- a/src/components/PremiumBadge.vue
+++ b/src/components/PremiumBadge.vue
@@ -1,0 +1,77 @@
+<template>
+  <span class="premium-badge" :style="badgeStyle" :title="title">
+    <span class="premium-badge__shimmer" aria-hidden="true"></span>
+    <svg class="premium-badge__icon" viewBox="0 0 24 24" width="12" height="12" aria-hidden="true">
+      <path d="M12 2 14.5 8.5 21.5 9 16 13.5 17.5 20.5 12 17 6.5 20.5 8 13.5 2.5 9 9.5 8.5z" fill="currentColor"/>
+    </svg>
+    <span class="premium-badge__label"><slot>Premium</slot></span>
+  </span>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  accent: { type: String, default: '#7c3aed' },
+  accentSoft: { type: String, default: '#a78bfa' },
+  title: { type: String, default: '' }
+})
+
+const badgeStyle = computed(() => ({
+  '--premium-a': props.accent,
+  '--premium-b': props.accentSoft
+}))
+</script>
+
+<style scoped>
+.premium-badge {
+  --premium-a: #7c3aed;
+  --premium-b: #a78bfa;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.6rem 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #fff;
+  background: linear-gradient(110deg, var(--premium-a), var(--premium-b), #22d3ee, var(--premium-a));
+  background-size: 300% 100%;
+  animation: premiumShift 6s ease-in-out infinite;
+  box-shadow: 0 4px 18px -6px color-mix(in oklab, var(--premium-a) 70%, transparent),
+              0 0 0 1px color-mix(in oklab, #fff 25%, transparent) inset;
+  overflow: hidden;
+  user-select: none;
+}
+
+.premium-badge__shimmer {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(115deg, transparent 25%, rgba(255,255,255,0.5) 50%, transparent 75%);
+  transform: translateX(-100%);
+  animation: premiumSheen 3.4s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.premium-badge__icon {
+  position: relative;
+  filter: drop-shadow(0 0 4px rgba(255,255,255,0.6));
+}
+
+.premium-badge__label {
+  position: relative;
+}
+
+@keyframes premiumShift {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}
+
+@keyframes premiumSheen {
+  0%, 60% { transform: translateX(-120%); }
+  85%, 100% { transform: translateX(120%); }
+}
+</style>

--- a/src/views/WorkshopOverview.vue
+++ b/src/views/WorkshopOverview.vue
@@ -42,8 +42,18 @@
           :id="wsIndex === 0 ? 'tour-workshop-card' : undefined"
           :key="ws"
           @click="openWorkshop(ws)"
-          class="group cursor-pointer transition-all duration-200 hover:shadow-lg hover:-translate-y-0.5 hover:border-primary/50 overflow-hidden"
+          class="group cursor-pointer transition-all duration-200 hover:shadow-lg hover:-translate-y-0.5 hover:border-primary/50 overflow-hidden relative"
+          :class="{ 'workshop-card--premium': isPremiumWorkshop(ws) }"
           :style="getWorkshopCardStyle(ws)">
+
+          <!-- Premium badge floating top-right -->
+          <div v-if="isPremiumWorkshop(ws)" class="absolute top-2.5 right-2.5 z-10">
+            <PremiumBadge
+              :accent="getWorkshopProvider(ws)?.accent_color || '#7c3aed'"
+              :accent-soft="getWorkshopProvider(ws)?.accent_color_soft || '#a78bfa'">
+              {{ isWorkshopUnlocked(ws) ? (isDE ? 'Freigeschaltet' : 'Unlocked') : (isDE ? 'Premium' : 'Premium') }}
+            </PremiumBadge>
+          </div>
 
           <!-- Color accent bar at top (always shown) -->
           <div class="h-1.5 bg-gradient-to-r from-primary to-secondary" :style="getWorkshopBarStyle(ws)"></div>
@@ -106,6 +116,20 @@
             <p v-if="getWorkshopDescription(ws)" class="text-sm text-muted-foreground leading-relaxed mb-3">
               {{ getWorkshopDescription(ws) }}
             </p>
+
+            <!-- Premium provider strip -->
+            <div v-if="isPremiumWorkshop(ws) && getWorkshopProvider(ws)?.name"
+                 class="mt-2 mb-2 flex items-center justify-between gap-2 text-xs">
+              <span class="text-muted-foreground">
+                {{ isDE ? 'Angeboten von' : 'Offered by' }}
+                <strong class="text-foreground">{{ getWorkshopProvider(ws).name }}</strong>
+              </span>
+              <span v-if="!isWorkshopUnlocked(ws) && getWorkshopProvider(ws).price_display"
+                    class="font-semibold"
+                    :style="{ color: getWorkshopProvider(ws).accent_color || '#7c3aed' }">
+                {{ getWorkshopProvider(ws).price_display }}
+              </span>
+            </div>
 
             <div v-if="isRemoteWorkshop(learning, ws)" class="flex items-center">
               <a
@@ -179,6 +203,10 @@ import { useLanguage } from '../composables/useLanguage'
 import { formatLangName } from '../utils/formatters'
 import { Card } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import PremiumBadge from '@/components/PremiumBadge.vue'
+import { usePremium } from '../composables/usePremium'
+
+const premium = usePremium()
 
 const emit = defineEmits(['update-title'])
 const router = useRouter()
@@ -361,6 +389,20 @@ function getWorkshopDescription(workshop) {
   return meta.description || null
 }
 
+function isPremiumWorkshop(workshop) {
+  const meta = getWorkshopMeta(learning.value, workshop)
+  return meta?.premium === true && !!meta?.provider
+}
+
+function getWorkshopProvider(workshop) {
+  const meta = getWorkshopMeta(learning.value, workshop)
+  return meta?.provider || null
+}
+
+function isWorkshopUnlocked(workshop) {
+  return premium.unlocked.value && premium.isUnlocked(learning.value, workshop)
+}
+
 function getWorkshopSourceLabel(workshop) {
   const sourceUrl = getSourceForSlug(learning.value, workshop)
   if (!sourceUrl) return ''
@@ -516,3 +558,32 @@ onUnmounted(() => {
   window.removeEventListener('content-sources-changed', onSourcesChanged)
 })
 </script>
+
+<style scoped>
+.workshop-card--premium {
+  position: relative;
+  isolation: isolate;
+}
+.workshop-card--premium::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  padding: 1.5px;
+  background: linear-gradient(120deg, #7c3aed, #22d3ee, #a78bfa, #7c3aed);
+  background-size: 300% 100%;
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  animation: premiumBorderShift 8s ease-in-out infinite;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.85;
+}
+@keyframes premiumBorderShift {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}
+</style>


### PR DESCRIPTION
## Summary

Closes #296.

Workshop-Karten mit `premium: true` bekommen drei klare visuelle Signale, damit Lernende Premium-Workshops schon in der Workshop-Liste erkennen — ohne erst reinklicken zu müssen.

## Was sich ändert

- **`PremiumBadge.vue`** (neu) — animiertes Aurora-Sternchen-Badge oben rechts in der Karte. Akzentfarbe aus `provider.accent_color`. Zeigt „Freigeschaltet" statt „Premium" wenn der Workshop für den Lernenden bereits offen ist (LocalStorage).
- **`WorkshopOverview.vue`** — Aurora-Rand um die Karte (animierter Farbverlauf cyan → violett, dezent). Anbieter-Strip am Karten-Fuß: „Angeboten von **\<Name\>**" + Preis in Anbieter-Akzentfarbe.

Kostenlose Workshops verhalten sich unverändert — kein Badge, kein Aurora-Rand, kein Strip.

Spec: [`specs/premium-badge-on-workshop-cards.md`](https://github.com/openlearnapp/openlearnapp.github.io/blob/feat/premium-badge-on-workshop-cards/specs/premium-badge-on-workshop-cards.md)

## Test plan

Lokal mit `pnpm dev` vor Merge testen:

- [ ] Workshop-Liste (`#/deutsch`) öffnen
- [ ] Premium-Workshop (mit `premium: true` in `workshops.yaml`) hat:
  - [ ] Animiertes Sternchen-Badge oben rechts in Anbieter-Akzentfarbe
  - [ ] Aurora-Rand um die Karte, läuft langsam
  - [ ] Anbieter-Strip am Fuß: „Angeboten von ..." + Preis rechts
- [ ] Kostenlose Workshops daneben — keine Badge, kein Aurora-Rand, kein Strip
- [ ] Klick auf Premium-Karte → führt in die Lessons-Overview wie gehabt
- [ ] Workshop nach Demo-Unlock erneut öffnen — Badge sagt „Freigeschaltet" statt „Premium", kein Preis im Strip

Nach Merge live auf https://open-learn.app/#/deutsch.

## Abhängigkeit

Setzt PR #294 voraus (Schema durchgereicht, Provider-Daten in `meta.provider`).