### PR TITLE
feat: creator onboarding section on home — sell paid courses

### DIFF
--- a/specs/creator-onboarding-on-home.md
+++ b/specs/creator-onboarding-on-home.md
@@ -1,0 +1,31 @@
+# Anbieter-Onboarding-Sektion auf der Startseite
+
+## Problem
+
+Workshop-Anbieter, die ihre Inhalte verkaufen wollen, finden auf der Open-Learn-Startseite keinen Hinweis, dass das technisch möglich ist. Premium-Features (PR #294, #297, #299) sind in der App vorhanden, aber neue Anbieter erfahren davon nicht — sie müssen erst auf `/creators` klicken und sich durchscrollen.
+
+## Lösung
+
+Eine prominente Sektion auf der Home (`#/`) zwischen den bestehenden Blöcken: „**Verkaufe deinen Kurs über Open Learn**". 
+
+### Visuell
+
+- Aurora-Hintergrund passend zum Premium-Look (cyan + violett)
+- Headline mit Gradient-Text
+- 4 nummerierte Schritte: YAML schreiben → Frei vs. Premium wählen → Verkaufsseite verlinken → Importieren lassen
+- Live-YAML-Snippet rechts, der die `premium:`-Felder zeigt — Anbieter sieht direkt wie es geht
+- Zwei CTAs: „Live-Demo ansehen" + „Workshop-Guide öffnen"
+
+### Wo sie sitzt
+
+Direkt vor dem Privacy-Block, in derselben Breite wie die anderen Home-Sektionen. Sticht durch die Aurora-Optik visuell raus — passt zum Premium-Branding, ohne den restlichen Home-Look zu brechen.
+
+## Was unverändert bleibt
+
+- Andere Home-Sektionen (Hero, Features, How it works, Roadmap, Privacy, Open Source) bleiben exakt wie heute
+- Kein neues Routing, kein neues View
+- Wer kostenlos Workshops bauen will, wird durch die Sektion nicht angesprochen — der „Workshop erstellen"-Link bleibt prominent
+
+## Abhängigkeit
+
+Setzt PR #294 (Backbone) voraus — verlinkt auf die Live-Demo und nutzt das dort eingeführte Schema in den Code-Beispielen.

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -93,22 +93,34 @@
             {{ $t('home.subtitle') }}
           </p>
 
-          <!-- Language Selector — Primary CTA -->
+          <!-- Split-Pille: links Sprach-Wahl, rechts Workshops-Action — eine zusammenhängende CTA -->
           <div class="relative">
-            <button
-              @click.stop="showLanguageMenu = !showLanguageMenu"
-              class="lang-cta flex items-center gap-2 px-7 py-3.5 rounded-2xl font-bold text-base shadow-xl transition-all"
-            >
-              <span class="text-xl leading-none">{{ getFlag(currentLanguage) }}</span>
-              <span>{{ formatLangName(currentLanguage) }}</span>
-              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="opacity-70 transition-transform" :class="showLanguageMenu ? 'rotate-180' : ''"><path d="m6 9 6 6 6-6"/></svg>
-            </button>
+            <div class="hero-split-cta">
+              <!-- Linke Zone: Sprache wählen -->
+              <button
+                @click.stop="showLanguageMenu = !showLanguageMenu"
+                class="hero-split-lang"
+                :aria-label="formatLangName(currentLanguage) + ' — Sprache wechseln'"
+              >
+                <span class="text-xl leading-none">{{ getFlag(currentLanguage) }}</span>
+                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="opacity-70 transition-transform" :class="showLanguageMenu ? 'rotate-180' : ''"><path d="m6 9 6 6 6-6"/></svg>
+              </button>
+
+              <!-- Trenn-Linie -->
+              <span class="hero-split-divider" aria-hidden="true"></span>
+
+              <!-- Rechte Zone: zur Workshop-Übersicht -->
+              <a :href="'#/' + currentLanguage" class="hero-split-action">
+                <span>{{ isDE ? 'Workshops auf' : 'Workshops in' }} {{ formatLangName(currentLanguage) }}</span>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="hero-split-arrow"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+              </a>
+            </div>
 
             <!-- Dropdown -->
             <Transition name="dropdown">
               <div
                 v-if="showLanguageMenu"
-                class="absolute top-full left-1/2 -translate-x-1/2 mt-2 bg-popover text-popover-foreground border border-border rounded-xl shadow-2xl overflow-hidden min-w-[200px] z-[100]"
+                class="absolute top-full left-0 mt-2 bg-popover text-popover-foreground border border-border rounded-xl shadow-2xl overflow-hidden min-w-[200px] z-[100]"
               >
                 <button
                   v-for="lang in learningLanguages"
@@ -125,14 +137,6 @@
               </div>
             </Transition>
           </div>
-
-          <!-- Secondary CTA -->
-          <a
-            :href="'#/' + currentLanguage"
-            class="mt-4 text-xs text-slate-300/60 hover:text-white transition underline underline-offset-4"
-          >
-            {{ $t('home.browseWorkshops') }} →
-          </a>
         </div>
 
         <!-- Bottom gradient fade -->
@@ -181,41 +185,63 @@
           </div>
 
           <div class="grid grid-cols-1 sm:grid-cols-3 gap-6 sm:gap-4 relative">
-            <!-- Step 1: Pick a language -->
-            <div class="hiw-step group">
+            <!-- Step 1: Pick a language — animierte Sprechblase (keine Duplizierung der Hero-Auswahl) -->
+            <div class="hiw-step">
               <div class="hiw-num" data-step="1">
                 <span>1</span>
                 <span class="hiw-num-glow" aria-hidden="true"></span>
               </div>
               <h4 class="hiw-title">{{ steps[0].title }}</h4>
-              <div class="relative inline-block mb-3">
-                <button
-                  @click="showLanguageMenu = !showLanguageMenu"
-                  class="hiw-action flex items-center gap-1.5"
-                >
-                  <span class="text-base leading-none">{{ getFlag(currentLanguage) }}</span>
-                  <span>{{ formatLangName(currentLanguage) }}</span>
-                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="opacity-70"><path d="m6 9 6 6 6-6"/></svg>
-                </button>
+              <div class="hiw-speak" aria-hidden="true">
+                <svg viewBox="0 0 100 70" width="100" height="70">
+                  <!-- Sprechblase -->
+                  <path d="M10 10 H 90 a 8 8 0 0 1 8 8 v 28 a 8 8 0 0 1 -8 8 H 38 l -10 10 v -10 H 10 a 8 8 0 0 1 -8 -8 V 18 a 8 8 0 0 1 8 -8 z"
+                        fill="color-mix(in srgb, hsl(var(--primary)) 12%, transparent)"
+                        stroke="hsl(var(--primary))" stroke-width="1.5" opacity="0.85"/>
+                  <!-- Audio-Wellen drinnen -->
+                  <line x1="22" y1="32" x2="22" y2="32" stroke="hsl(var(--primary))" stroke-width="3" stroke-linecap="round" class="hiw-wave hiw-wave-1"/>
+                  <line x1="32" y1="32" x2="32" y2="32" stroke="hsl(var(--primary))" stroke-width="3" stroke-linecap="round" class="hiw-wave hiw-wave-2"/>
+                  <line x1="42" y1="32" x2="42" y2="32" stroke="hsl(var(--primary))" stroke-width="3" stroke-linecap="round" class="hiw-wave hiw-wave-3"/>
+                  <line x1="52" y1="32" x2="52" y2="32" stroke="hsl(var(--primary))" stroke-width="3" stroke-linecap="round" class="hiw-wave hiw-wave-4"/>
+                  <line x1="62" y1="32" x2="62" y2="32" stroke="hsl(var(--primary))" stroke-width="3" stroke-linecap="round" class="hiw-wave hiw-wave-5"/>
+                  <line x1="72" y1="32" x2="72" y2="32" stroke="hsl(var(--primary))" stroke-width="3" stroke-linecap="round" class="hiw-wave hiw-wave-6"/>
+                </svg>
               </div>
               <p class="hiw-desc">{{ steps[0].desc }}</p>
             </div>
 
-            <!-- Step 2: Start a Workshop -->
-            <div class="hiw-step group">
+            <!-- Step 2: Start a Workshop — Workshop-Karten-Mockups + animierter Cursor -->
+            <div class="hiw-step">
               <div class="hiw-num" data-step="2">
                 <span>2</span>
                 <span class="hiw-num-glow" aria-hidden="true"></span>
               </div>
               <h4 class="hiw-title">{{ steps[1].title }}</h4>
-              <a :href="'#/' + currentLanguage" class="hiw-action inline-flex items-center gap-1.5">
-                {{ $t('home.browseWorkshops') }} →
-              </a>
-              <p class="hiw-desc mt-3">{{ steps[1].desc }}</p>
+              <div class="hiw-tiles" aria-hidden="true">
+                <span class="hiw-tile hiw-tile--1" style="--tc: #10b981;">
+                  <span class="hiw-tile-bar"></span>
+                  <span class="hiw-tile-line hiw-tile-line--w1"></span>
+                  <span class="hiw-tile-line hiw-tile-line--w2"></span>
+                </span>
+                <span class="hiw-tile hiw-tile--2" style="--tc: #a855f7;">
+                  <span class="hiw-tile-bar"></span>
+                  <span class="hiw-tile-line hiw-tile-line--w1"></span>
+                  <span class="hiw-tile-line hiw-tile-line--w2"></span>
+                </span>
+                <span class="hiw-tile hiw-tile--3" style="--tc: #f59e0b;">
+                  <span class="hiw-tile-bar"></span>
+                  <span class="hiw-tile-line hiw-tile-line--w1"></span>
+                  <span class="hiw-tile-line hiw-tile-line--w2"></span>
+                </span>
+                <span class="hiw-cursor">
+                  <svg width="14" height="16" viewBox="0 0 24 28" fill="currentColor"><path d="M2 2l8 22 3-9 9-3z"/></svg>
+                </span>
+              </div>
+              <p class="hiw-desc">{{ steps[1].desc }}</p>
             </div>
 
-            <!-- Step 3: Learn & Track -->
-            <div class="hiw-step group">
+            <!-- Step 3: Learn & Track — Progress-Bars + Completion-Check -->
+            <div class="hiw-step">
               <div class="hiw-num" data-step="3">
                 <span>3</span>
                 <span class="hiw-num-glow" aria-hidden="true"></span>
@@ -297,68 +323,258 @@
         </div>
       </div>
 
-      <!-- ══ BUILT-IN TOOLS ══ -->
-      <div class="mb-8">
-        <h3 class="text-lg font-semibold text-foreground mb-3">{{ $t('home.builtInTools') }}</h3>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <div v-for="tool in tools" :key="tool.key" class="p-3 rounded-lg border border-border">
-            <div class="flex items-center gap-2 mb-1">
-              <span class="text-base">{{ tool.icon }}</span>
-              <span class="text-sm font-medium text-foreground">{{ tool.title }}</span>
+      <!-- ══ BUILT-IN TOOLS — Video-Player Showcase: zykliert durch alle Tools live ══ -->
+      <div class="mb-12">
+        <h3 class="text-lg font-semibold text-foreground mb-1">{{ $t('home.builtInTools') }}</h3>
+        <p class="text-sm text-muted-foreground mb-5">{{ $t('home.builtInToolsDesc', 'Alles was du zum Lernen brauchst — eingebaut, kein Setup nötig.') }}</p>
+
+        <div
+          class="tvp-frame"
+          @mouseenter="tvpHover = true"
+          @mouseleave="tvpHover = false"
+        >
+          <!-- Live-Bild: aktuelles Tool -->
+          <div class="tvp-screen" :style="{ '--c': toolColor(currentTool.key) }">
+            <!-- Ambient color wash background -->
+            <div class="tvp-wash" :style="{ '--c': toolColor(currentTool.key) }"></div>
+
+            <!-- Floating particles per tool color -->
+            <svg class="tvp-particles" viewBox="0 0 800 360" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+              <circle v-for="(p, i) in tvpParticles" :key="i"
+                :cx="p.x + Math.sin(animFrame * 0.025 + p.phase) * 30"
+                :cy="p.y + Math.cos(animFrame * 0.03 + p.phase) * 18"
+                :r="p.r"
+                :fill="toolColor(currentTool.key)"
+                :opacity="0.1 + Math.sin(animFrame * 0.05 + p.phase) * 0.08" />
+            </svg>
+
+            <!-- Tool content (animated entry per change) -->
+            <Transition name="tvp-fade" mode="out-in">
+              <div :key="currentTool.key" class="tvp-content">
+                <div class="tvp-icon" :style="{ color: toolColor(currentTool.key), '--c': toolColor(currentTool.key) }">
+                  <component :is="toolIcon(currentTool.key)" class="w-16 h-16 sm:w-20 sm:h-20" />
+                </div>
+                <h4 class="tvp-title">{{ currentTool.title }}</h4>
+                <p class="tvp-desc">{{ currentTool.desc }}</p>
+              </div>
+            </Transition>
+
+            <!-- Live-Indicator -->
+            <div class="tvp-live" aria-hidden="true">
+              <span class="tvp-live-dot"></span>
+              <span class="tvp-live-text">LIVE</span>
             </div>
-            <p class="text-xs text-muted-foreground">{{ tool.desc }}</p>
+
+            <!-- Tool counter top-right -->
+            <div class="tvp-counter">{{ tvpIndex + 1 }} / {{ tools.length }}</div>
+
+            <!-- Großer zentrierter Play/Pause-Button — click überall im Player toggelt -->
+            <button
+              class="tvp-center-play"
+              :class="{ 'tvp-center-play--playing': tvpPlaying }"
+              @click.stop="tvpPlaying = !tvpPlaying"
+              :aria-label="tvpPlaying ? 'Pause' : 'Play'"
+            >
+              <svg v-if="tvpPlaying" width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M6 5h4v14H6zm8 0h4v14h-4z"/></svg>
+              <svg v-else width="32" height="32" viewBox="0 0 24 24" fill="currentColor" style="margin-left:3px"><path d="M8 5v14l11-7z"/></svg>
+            </button>
+          </div>
+
+          <!-- Controls overlay (transparent, hover-reveal) -->
+          <div class="tvp-controls" :class="{ 'tvp-controls--show': tvpHover || !tvpPlaying }">
+            <!-- Scrub track with tool-marker pills -->
+            <div class="tvp-track" @click="onTvpScrubClick">
+              <!-- Progress fill -->
+              <div class="tvp-progress" :style="{ width: tvpProgress + '%' }"></div>
+              <!-- Tool markers (clickable) -->
+              <button
+                v-for="(tool, i) in tools"
+                :key="tool.key"
+                class="tvp-marker"
+                :class="{ 'tvp-marker--active': i === tvpIndex }"
+                :style="{ left: ((i + 0.5) / tools.length * 100) + '%', '--c': toolColor(tool.key) }"
+                @click.stop="tvpSeek(i)"
+                :aria-label="tool.title"
+              ></button>
+            </div>
+
+            <!-- Time / tool name -->
+            <span class="tvp-time">{{ currentTool.title }}</span>
           </div>
         </div>
       </div>
 
-      <!-- ══ FOR CREATORS ══ -->
-      <div class="mb-8 p-5 rounded-xl border border-border bg-accent/10">
-        <div class="flex items-start gap-4">
-          <span class="text-3xl flex-shrink-0">✏️</span>
-          <div>
-            <h3 class="text-lg font-semibold text-foreground mb-1">{{ $t('home.forCreators') }}</h3>
-            <p class="text-sm text-muted-foreground mb-3">{{ $t('home.forCreatorsDesc') }}</p>
-            <a href="#/creators" class="text-sm font-medium text-primary hover:underline">{{ $t('home.forCreatorsLink') }} →</a>
+      <!-- ══ FOR CREATORS — Gradient-Panel mit Pencil-Icon + YAML-Mockup ══ -->
+      <a href="#/creators" class="creator-card group mb-12">
+        <div class="creator-icon">
+          <component :is="IconPencil" class="w-7 h-7" />
+        </div>
+        <div class="creator-text flex-1 min-w-0">
+          <h3 class="creator-title">{{ $t('home.forCreators') }}</h3>
+          <p class="creator-desc">{{ $t('home.forCreatorsDesc') }}</p>
+          <span class="creator-link">{{ $t('home.forCreatorsLink') }} <span class="creator-arrow">→</span></span>
+        </div>
+        <!-- YAML-Mockup als Illustration -->
+        <div class="creator-yaml" aria-hidden="true">
+          <div class="creator-yaml-window">
+            <div class="creator-yaml-dots">
+              <span></span><span></span><span></span>
+            </div>
+            <div class="creator-yaml-line"><span class="creator-yaml-key">title:</span><span class="creator-yaml-val">"Lesson 1"</span></div>
+            <div class="creator-yaml-line"><span class="creator-yaml-key">examples:</span></div>
+            <div class="creator-yaml-line creator-yaml-indent"><span class="creator-yaml-dash">-</span><span class="creator-yaml-key">q:</span><span class="creator-yaml-val">"Frage"</span></div>
+            <div class="creator-yaml-line creator-yaml-indent"><span class="creator-yaml-key">a:</span><span class="creator-yaml-val">"Antwort"</span></div>
           </div>
+        </div>
+      </a>
+
+      <!-- ══ FOR PROVIDERS — Bezahlten Workshop anbieten ══ -->
+      <div class="provider-card mb-12">
+        <div class="provider-card__aurora" aria-hidden="true"></div>
+        <div class="provider-card__grid" aria-hidden="true"></div>
+
+        <div class="provider-card__head">
+          <div class="provider-card__badge">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M12 2 14.5 8.5 21.5 9 16 13.5 17.5 20.5 12 17 6.5 20.5 8 13.5 2.5 9 9.5 8.5z" fill="currentColor"/>
+            </svg>
+            {{ isDE ? 'Für Kursanbieter' : 'For Course Providers' }}
+          </div>
+          <h3 class="provider-card__title">
+            {{ isDE
+              ? 'Deinen Kurs auf Open Learn verkaufen'
+              : 'Sell your course on Open Learn' }}
+          </h3>
+          <p class="provider-card__lead">
+            {{ isDE
+              ? 'Du bringst den Inhalt — wir machen daraus einen Lernpfad mit Audio, Quiz und Fortschritt. Lege fest, welche Lektionen frei zugänglich sind und auf welcher Seite Lernende kaufen.'
+              : 'You bring the content — we turn it into a learning path with audio, quiz and progress. Decide which lessons are free and where learners check out.' }}
+          </p>
+        </div>
+
+        <div class="provider-card__cols">
+          <ol class="provider-card__steps">
+            <li>
+              <span class="provider-card__num">1</span>
+              <div>
+                <strong>{{ isDE ? 'Workshop schreiben' : 'Author your workshop' }}</strong>
+                <p>{{ isDE ? 'Lektionen als YAML — wie jeder andere Open-Learn-Workshop.' : 'Lessons as YAML — like any other Open Learn workshop.' }}</p>
+              </div>
+            </li>
+            <li>
+              <span class="provider-card__num">2</span>
+              <div>
+                <strong>{{ isDE ? 'Frei vs. Premium festlegen' : 'Choose free vs premium' }}</strong>
+                <p>{{ isDE ? 'Per Zahl die ersten N freigeben — oder einzelne Lektionen markieren. Komplett kostenlos geht auch.' : 'Free the first N lessons — or pick individual ones. Fully free is also fine.' }}</p>
+              </div>
+            </li>
+            <li>
+              <span class="provider-card__num">3</span>
+              <div>
+                <strong>{{ isDE ? 'Verkaufsseite verlinken' : 'Link your checkout' }}</strong>
+                <p>{{ isDE ? 'Eigene Landing-Page + Checkout. Open Learn führt Lernende elegant dorthin.' : 'Your own landing page + checkout. Open Learn guides learners there.' }}</p>
+              </div>
+            </li>
+            <li>
+              <span class="provider-card__num">4</span>
+              <div>
+                <strong>{{ isDE ? 'Importieren lassen' : 'Get imported' }}</strong>
+                <p>{{ isDE ? 'Workshop-URL teilen — Open Learn rendert Banner, Schlösser und Kauf-CTA.' : 'Share the workshop URL — Open Learn renders banner, locks and buy CTA.' }}</p>
+              </div>
+            </li>
+          </ol>
+
+          <div class="provider-card__yaml" aria-label="workshops.yaml — Premium-Felder">
+            <div class="provider-card__yaml-window">
+              <div class="provider-card__yaml-dots">
+                <span></span><span></span><span></span>
+                <span class="provider-card__yaml-file">workshops.yaml</span>
+              </div>
+              <pre class="provider-card__yaml-body"><span class="hl-key">title:</span> <span class="hl-val">"Mein Kurs"</span>
+<span class="hl-key">premium:</span> <span class="hl-bool">true</span>
+<span class="hl-key">free_lessons:</span> <span class="hl-num">2</span>
+<span class="hl-comment"># oder pro Lektion:</span>
+<span class="hl-key">free_lesson_numbers:</span> [<span class="hl-num">0</span>, <span class="hl-num">1</span>, <span class="hl-num">5</span>]
+<span class="hl-key">total_lessons:</span> <span class="hl-num">13</span>
+<span class="hl-key">provider:</span>
+  <span class="hl-key">name:</span> <span class="hl-val">"Mein Anbieter"</span>
+  <span class="hl-key">landing_url:</span> <span class="hl-val">"https://..."</span>
+  <span class="hl-key">accent_color:</span> <span class="hl-val">"#7c3aed"</span>
+  <span class="hl-key">price_display:</span> <span class="hl-val">"49 €"</span></pre>
+            </div>
+          </div>
+        </div>
+
+        <div class="provider-card__cta-row">
+          <a href="#/deutsch/local-dev:linux-grundlagen-preview/lessons" class="provider-card__cta provider-card__cta--primary">
+            {{ isDE ? 'Demo ansehen' : 'View live demo' }}
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m13 6 6 6-6 6"/></svg>
+          </a>
+          <a href="#/creators" class="provider-card__cta provider-card__cta--ghost">
+            {{ isDE ? 'Workshop-Guide öffnen' : 'Open creator guide' }}
+          </a>
         </div>
       </div>
 
-      <!-- ══ PRIVACY ══ -->
-      <div class="mb-8">
-        <h3 class="text-lg font-semibold text-foreground mb-3">{{ $t('home.privacyTitle') }}</h3>
+      <!-- ══ PRIVACY — 3 themed Karten mit Icons ══ -->
+      <div class="mb-12">
+        <h3 class="text-lg font-semibold text-foreground mb-1">{{ $t('home.privacyTitle') }}</h3>
+        <p class="text-sm text-muted-foreground mb-5">Deine Daten gehören dir — keine Konten, kein Tracking, voller Export.</p>
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          <div v-for="item in privacyPoints" :key="item.key" class="p-3 rounded-lg bg-accent/20">
-            <div class="text-sm font-medium text-foreground mb-1">{{ item.title }}</div>
-            <p class="text-xs text-muted-foreground">{{ item.desc }}</p>
-          </div>
-        </div>
-      </div>
-
-      <!-- ══ ROADMAP ══ -->
-      <div class="mb-8">
-        <h3 class="text-lg font-semibold text-foreground mb-3">{{ $t('home.roadmapTitle') }}</h3>
-        <p class="text-sm text-muted-foreground mb-4">{{ $t('home.roadmapDesc') }}</p>
-        <div class="space-y-2">
-          <div v-for="item in roadmapItems" :key="item.key"
-            :class="['flex items-start gap-3 p-3 rounded-lg border', item.done ? 'border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-900/20' : 'border-border']">
-            <span class="text-base mt-0.5">{{ item.icon }}</span>
-            <div class="flex-grow">
-              <div :class="['text-sm font-medium', item.done ? 'text-green-700 dark:text-green-400 line-through' : 'text-foreground']">{{ item.title }}</div>
-              <p class="text-xs text-muted-foreground">{{ item.desc }}</p>
+          <div
+            v-for="item in privacyPoints"
+            :key="item.key"
+            class="privacy-card"
+            :style="{ '--c': privacyColor(item.key) }"
+          >
+            <div class="privacy-icon">
+              <component :is="privacyIcon(item.key)" class="w-5 h-5" />
             </div>
-            <a v-if="item.issue" :href="'https://github.com/openlearnapp/openlearnapp.github.io/issues/' + item.issue" target="_blank" rel="noopener" class="text-xs text-primary hover:underline flex-shrink-0" @click.stop>#{{ item.issue }}</a>
+            <div>
+              <h4 class="privacy-title">{{ item.title }}</h4>
+              <p class="privacy-desc">{{ item.desc }}</p>
+            </div>
           </div>
         </div>
       </div>
 
-      <!-- ══ OPEN SOURCE ══ -->
-      <div class="mb-8 p-5 rounded-xl border border-primary/20 bg-primary/5 text-center">
-        <h3 class="text-lg font-semibold text-foreground mb-2">{{ $t('home.openSourceTitle') }}</h3>
-        <p class="text-sm text-muted-foreground mb-4">{{ $t('home.openSourceDesc') }}</p>
-        <a href="https://github.com/openlearnapp/openlearnapp.github.io" target="_blank" rel="noopener"
-          class="inline-block px-5 py-2 text-sm font-medium text-white bg-primary rounded-lg hover:bg-primary/90 transition">
-          {{ $t('home.viewOnGitHub') }}
-        </a>
+      <!-- ══ ROADMAP — Status-Liste mit Dots und Progress-Indikatoren ══ -->
+      <div class="mb-12">
+        <h3 class="text-lg font-semibold text-foreground mb-1">{{ $t('home.roadmapTitle') }}</h3>
+        <p class="text-sm text-muted-foreground mb-5">{{ $t('home.roadmapDesc') }}</p>
+        <div class="roadmap-list">
+          <div
+            v-for="item in roadmapItems"
+            :key="item.key"
+            class="roadmap-item"
+            :class="{ 'roadmap-item--done': item.done }"
+          >
+            <span class="roadmap-dot" aria-hidden="true">
+              <svg v-if="item.done" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12.5l4 4 10-10"/></svg>
+            </span>
+            <div class="flex-grow min-w-0">
+              <div class="roadmap-title">{{ item.title }}</div>
+              <p class="roadmap-desc">{{ item.desc }}</p>
+            </div>
+            <a v-if="item.issue" :href="'https://github.com/openlearnapp/openlearnapp.github.io/issues/' + item.issue" target="_blank" rel="noopener" class="roadmap-issue" @click.stop>#{{ item.issue }}</a>
+          </div>
+        </div>
+      </div>
+
+      <!-- ══ OPEN SOURCE — Dark Gradient-Panel mit GitHub-Icon ══ -->
+      <div class="os-card mb-8">
+        <div class="os-bg" aria-hidden="true"></div>
+        <div class="os-content">
+          <div class="os-icon">
+            <component :is="IconGitHub" class="w-10 h-10" />
+          </div>
+          <h3 class="os-title">{{ $t('home.openSourceTitle') }}</h3>
+          <p class="os-desc">{{ $t('home.openSourceDesc') }}</p>
+          <a href="https://github.com/openlearnapp/openlearnapp.github.io" target="_blank" rel="noopener" class="os-cta">
+            <component :is="IconGitHub" class="w-4 h-4" />
+            <span>{{ $t('home.viewOnGitHub') }}</span>
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -465,7 +681,7 @@ const privacyPoints = computed(() => [
 ])
 
 const roadmapItems = computed(() => [
-  { key: 'coach',  icon: '🤖', title: t('home.roadmap.aiCoach'),  desc: t('home.roadmap.aiCoachDesc'),  issue: 45 },
+  { key: 'coach',  icon: '✨', title: t('home.roadmap.aiCoach'),  desc: t('home.roadmap.aiCoachDesc'),  issue: 45 },
   { key: 'kids',   icon: '🧒', title: t('home.roadmap.kidsMode'), desc: t('home.roadmap.kidsModeDesc'), issue: 46 },
   { key: 'images', icon: '🖼️', title: t('home.roadmap.images'),  desc: t('home.roadmap.imagesDesc'),   issue: 47 },
   { key: 'i18n',   icon: '✅', title: t('home.roadmap.i18n'),     desc: t('home.roadmap.i18nDesc'),     issue: 44, done: true },
@@ -544,6 +760,117 @@ function onFeatMove(e, key) {
   featActive.value = key
 }
 
+// ── Built-in Tools: Custom Icons + Themen-Farben ──
+const IconCheck = makeIcon('#10b981', [
+  'M5 12.5l4 4 10-10',
+  'M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5z',
+])
+const IconSpeaker = makeIcon('#06b6d4', [
+  'M11 5L6 9H3a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h3l5 4V5z',
+  'M15.5 8.5a5 5 0 0 1 0 7',
+  'M18.5 5.5a9 9 0 0 1 0 13',
+])
+const IconVideoCam = makeIcon('#f472b6', [
+  'M3 6a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6z',
+  'M17 10l5-3v10l-5-3',
+])
+const IconChart = makeIcon('#f59e0b', [
+  'M3 21h18',
+  'M6 17V11',
+  'M11 17V7',
+  'M16 17v-9',
+  'M21 17V4',
+])
+const IconCoach = makeIcon('#818cf8', [
+  'M22 9L12 5 2 9l10 4 10-4z',
+  'M6 11v5c0 1.7 2.7 3 6 3s6-1.3 6-3v-5',
+  'M22 9v6',
+])
+const IconSync = makeIcon('#a78bfa', [
+  'M21 12a9 9 0 0 1-15.5 6.4L3 16',
+  'M3 12a9 9 0 0 1 15.5-6.4L21 8',
+  'M21 4v4h-4',
+  'M3 20v-4h4',
+])
+
+const TOOL_ICONS  = { quiz: IconCheck, audio: IconSpeaker, video: IconVideoCam, progress: IconChart, coach: IconCoach, sync: IconSync }
+const TOOL_COLORS = { quiz: '#10b981', audio: '#06b6d4', video: '#f472b6', progress: '#f59e0b', coach: '#818cf8', sync: '#a78bfa' }
+function toolIcon(key)  { return TOOL_ICONS[key]  || IconCheck }
+function toolColor(key) { return TOOL_COLORS[key] || '#10b981' }
+
+// ── Icons für For-Creators / Privacy / Roadmap / Open-Source ──
+const IconLock = makeIcon('#10b981', [
+  'M5 11h14a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-8a1 1 0 0 1 1-1z',
+  'M8 11V8a4 4 0 0 1 8 0v3',
+])
+const IconEyeOff = makeIcon('#06b6d4', [
+  'M2 12s3-7 10-7c2.4 0 4.4 0.8 6 2',
+  'M22 12s-3 7-10 7c-2.4 0-4.4-0.8-6-2',
+  'M9 9.5A3 3 0 0 0 12 15a3 3 0 0 0 2.6-1.5',
+  'M3 3l18 18',
+])
+const IconExport = makeIcon('#a78bfa', [
+  'M12 3v12',
+  'M7 8l5-5 5 5',
+  'M3 17v3a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-3',
+])
+const IconGitHub = makeIcon('#f8fafc', [
+  'M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.7c-2.78.6-3.37-1.34-3.37-1.34-.46-1.16-1.12-1.47-1.12-1.47-.91-.62.07-.61.07-.61 1.01.07 1.54 1.04 1.54 1.04.9 1.53 2.35 1.09 2.92.83.09-.65.35-1.09.64-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.09.39-1.99 1.03-2.69-.1-.25-.45-1.27.1-2.65 0 0 .84-.27 2.75 1.02a9.6 9.6 0 0 1 5 0c1.91-1.29 2.75-1.02 2.75-1.02.55 1.38.2 2.4.1 2.65.64.7 1.03 1.6 1.03 2.69 0 3.84-2.34 4.69-4.57 4.93.36.31.68.92.68 1.85v2.74c0 .27.18.58.69.48A10 10 0 0 0 12 2z',
+])
+
+const PRIVACY_ICONS  = { local: IconLock, notrack: IconEyeOff, export: IconExport }
+const PRIVACY_COLORS = { local: '#10b981', notrack: '#06b6d4', export: '#a78bfa' }
+function privacyIcon(key)  { return PRIVACY_ICONS[key]  || IconLock }
+function privacyColor(key) { return PRIVACY_COLORS[key] || '#10b981' }
+
+// ── Tool-Video-Player Logik ──
+const TVP_SECONDS_PER_TOOL = 3.2
+const tvpIndex = ref(0)
+const tvpProgress = ref(0)       // 0..100 (gesamt über alle Tools)
+const tvpPlaying = ref(true)
+const tvpHover = ref(false)
+let tvpRaf = null
+let tvpLast = 0
+
+const currentTool = computed(() => tools.value[tvpIndex.value] || tools.value[0])
+
+function tvpTick(now) {
+  if (tvpPlaying.value) {
+    const dt = (now - tvpLast) / 1000
+    const total = tools.value.length * TVP_SECONDS_PER_TOOL
+    tvpProgress.value = (tvpProgress.value + (dt / total) * 100) % 100
+    tvpIndex.value = Math.min(
+      tools.value.length - 1,
+      Math.floor((tvpProgress.value / 100) * tools.value.length)
+    )
+  }
+  tvpLast = now
+  tvpRaf = requestAnimationFrame(tvpTick)
+}
+
+function tvpSeek(i) {
+  tvpIndex.value = i
+  tvpProgress.value = (i / tools.value.length) * 100
+}
+
+function onTvpScrubClick(e) {
+  const rect = e.currentTarget.getBoundingClientRect()
+  const pct = ((e.clientX - rect.left) / rect.width) * 100
+  tvpProgress.value = Math.max(0, Math.min(100, pct))
+  tvpIndex.value = Math.min(
+    tools.value.length - 1,
+    Math.floor((tvpProgress.value / 100) * tools.value.length)
+  )
+}
+
+// Particles for video screen background
+const tvpParticles = Array.from({ length: 22 }, (_, i) => ({
+  x: (i * 73.3 + 30) % 800,
+  y: (i * 51.7 + 22) % 360,
+  r: 1.5 + (i % 3) * 1.2,
+  phase: i * 0.43,
+}))
+
 // ── Use-Case Panel: Maus-Parallax + Partikel ──
 const ucPanelX = ref(0)
 function onUcPanelMove(e) {
@@ -568,6 +895,7 @@ onMounted(async () => {
   document.addEventListener('click', handleClickOutside)
   window.addEventListener('scroll', onScroll, { passive: true })
   rafId = requestAnimationFrame(tick)
+  tvpRaf = requestAnimationFrame(tvpTick)
 
   const isStandalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true
   if (isStandalone) {
@@ -585,6 +913,7 @@ onUnmounted(() => {
   document.removeEventListener('click', handleClickOutside)
   window.removeEventListener('scroll', onScroll)
   if (rafId) cancelAnimationFrame(rafId)
+  if (tvpRaf) cancelAnimationFrame(tvpRaf)
 })
 </script>
 
@@ -604,26 +933,583 @@ onUnmounted(() => {
 .hero-wrap::before { top: 0;    background: linear-gradient(to bottom, rgba(0,0,0,0.5), transparent); }
 .hero-wrap::after  { bottom: 0; background: linear-gradient(to top,   rgba(0,0,0,0.3), transparent); }
 
-/* Primary language CTA button */
-.lang-cta {
+/* Split-Pille: links Sprach-Wahl, rechts Workshops-Action */
+.hero-split-cta {
+  display: inline-flex;
+  align-items: stretch;
   background: rgba(255,255,255,0.12);
   border: 1.5px solid rgba(255,255,255,0.3);
   backdrop-filter: blur(8px);
-  color: #fff;
+  border-radius: 999px;
+  overflow: hidden;
   box-shadow: 0 0 40px rgba(99,102,241,0.3), 0 4px 20px rgba(0,0,0,0.4);
-  transition: transform 0.2s, background 0.2s, box-shadow 0.2s;
+  transition: box-shadow 0.3s, border-color 0.3s;
 }
-.lang-cta:hover {
-  transform: scale(1.04);
-  background: rgba(99,102,241,0.25);
+.hero-split-cta:hover {
   border-color: rgba(99,102,241,0.6);
-  box-shadow: 0 0 60px rgba(99,102,241,0.4), 0 4px 24px rgba(0,0,0,0.5);
+  box-shadow: 0 0 60px rgba(99,102,241,0.45), 0 6px 28px rgba(0,0,0,0.5);
+}
+
+.hero-split-lang {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 14px 12px 18px;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.2s;
+  background: transparent;
+  border: 0;
+}
+.hero-split-lang:hover { background: rgba(255,255,255,0.08); }
+
+.hero-split-divider {
+  width: 1px;
+  background: rgba(255,255,255,0.25);
+  align-self: stretch;
+  margin: 6px 0;
+}
+
+.hero-split-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 22px;
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.95rem;
+  text-decoration: none;
+  letter-spacing: -0.01em;
+  transition: background 0.2s, gap 0.2s;
+}
+.hero-split-action:hover {
+  background: rgba(99,102,241,0.22);
+  gap: 12px;
+}
+.hero-split-arrow {
+  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.hero-split-action:hover .hero-split-arrow {
+  transform: translateX(3px);
 }
 
 /* Dropdown transition */
 .dropdown-enter-active, .dropdown-leave-active { transition: opacity 0.15s, transform 0.15s; }
 .dropdown-enter-from, .dropdown-leave-to { opacity: 0; transform: translateY(-6px) translateX(-50%); }
 .dropdown-enter-to, .dropdown-leave-from { transform: translateY(0) translateX(-50%); }
+
+/* ── Tool-Video-Player Showcase ── */
+.tvp-frame {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  max-height: 440px;
+  border-radius: 20px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #050810 0%, #0c0f1f 100%);
+  border: 1px solid rgba(255,255,255,0.08);
+  box-shadow:
+    0 24px 60px -16px rgba(0,0,0,0.4),
+    inset 0 1px 0 rgba(255,255,255,0.06);
+  isolation: isolate;
+}
+.tvp-screen {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.6s ease;
+}
+.tvp-wash {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 30% 30%, color-mix(in srgb, var(--c) 30%, transparent) 0%, transparent 50%),
+    radial-gradient(ellipse at 70% 70%, color-mix(in srgb, var(--c) 20%, transparent) 0%, transparent 55%);
+  transition: background 0.6s ease;
+  pointer-events: none;
+}
+.tvp-particles {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.tvp-content {
+  position: relative;
+  z-index: 2;
+  text-align: center;
+  padding: 24px;
+  max-width: 80%;
+}
+.tvp-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  border-radius: 24px;
+  background: color-mix(in srgb, var(--c) 12%, rgba(0,0,0,0.4));
+  border: 1px solid color-mix(in srgb, var(--c) 30%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--c) 25%, transparent),
+    0 10px 30px -8px color-mix(in srgb, var(--c) 50%, transparent);
+  margin-bottom: 18px;
+  filter: drop-shadow(0 0 16px currentColor);
+}
+.tvp-title {
+  font-size: clamp(1.4rem, 3.4vw, 2.2rem);
+  font-weight: 800;
+  color: #f8fafc;
+  margin-bottom: 8px;
+  letter-spacing: -0.02em;
+  text-shadow: 0 2px 12px rgba(0,0,0,0.5);
+}
+.tvp-desc {
+  font-size: clamp(0.85rem, 1.6vw, 1rem);
+  color: rgba(248,250,252,0.75);
+  line-height: 1.5;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+/* Fade transition zwischen Tools */
+.tvp-fade-enter-active, .tvp-fade-leave-active { transition: opacity 0.4s, transform 0.4s; }
+.tvp-fade-enter-from { opacity: 0; transform: translateY(8px) scale(0.98); }
+.tvp-fade-leave-to   { opacity: 0; transform: translateY(-8px) scale(0.98); }
+
+/* Live-Indicator */
+.tvp-live {
+  position: absolute;
+  top: 14px;
+  left: 14px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px 4px 8px;
+  border-radius: 999px;
+  background: rgba(0,0,0,0.45);
+  backdrop-filter: blur(8px);
+  z-index: 5;
+}
+.tvp-live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #ef4444;
+  animation: tvp-blink 1.4s ease-in-out infinite;
+}
+.tvp-live-text {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: #f8fafc;
+}
+@keyframes tvp-blink {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(239,68,68,0.6); }
+  50%      { opacity: 0.5; box-shadow: 0 0 0 6px rgba(239,68,68,0); }
+}
+
+.tvp-counter {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(0,0,0,0.45);
+  backdrop-filter: blur(8px);
+  font-size: 11px;
+  font-weight: 600;
+  color: rgba(248,250,252,0.8);
+  letter-spacing: 0.04em;
+  z-index: 5;
+}
+
+/* ── Controls Overlay ── */
+.tvp-controls {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px;
+  background: linear-gradient(to top, rgba(0,0,0,0.65), transparent);
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.3s, transform 0.3s;
+  z-index: 6;
+}
+.tvp-controls--show { opacity: 1; transform: translateY(0); }
+
+/* Großer zentrierter Play/Pause-Button — wechselt Visibility je nach Spielstatus */
+.tvp-center-play {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 76px;
+  height: 76px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255,255,255,0.16);
+  border: 2px solid rgba(255,255,255,0.55);
+  backdrop-filter: blur(10px);
+  color: #fff;
+  cursor: pointer;
+  z-index: 10;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.2);
+  transition: transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1),
+              background 0.25s,
+              opacity 0.35s,
+              border-color 0.25s;
+}
+.tvp-center-play:hover {
+  background: rgba(255,255,255,0.28);
+  border-color: rgba(255,255,255,0.8);
+  transform: translate(-50%, -50%) scale(1.08);
+}
+.tvp-center-play:active {
+  transform: translate(-50%, -50%) scale(0.94);
+}
+/* Während Wiedergabe: ausblenden, nur bei Hover über Player zeigen */
+.tvp-center-play--playing {
+  opacity: 0;
+}
+.tvp-frame:hover .tvp-center-play--playing {
+  opacity: 0.85;
+}
+
+/* Scrub bar */
+.tvp-track {
+  position: relative;
+  flex: 1;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+.tvp-track::before {
+  content: '';
+  position: absolute;
+  left: 0; right: 0;
+  height: 3px;
+  border-radius: 3px;
+  background: rgba(255,255,255,0.15);
+}
+.tvp-progress {
+  position: absolute;
+  left: 0;
+  height: 3px;
+  border-radius: 3px;
+  background: linear-gradient(90deg, rgba(255,255,255,0.7), #fff);
+  transition: width 0.05s linear;
+  pointer-events: none;
+}
+.tvp-marker {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--c);
+  border: 2px solid rgba(255,255,255,0.7);
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+  padding: 0;
+}
+.tvp-marker:hover {
+  transform: translate(-50%, -50%) scale(1.3);
+  box-shadow: 0 0 12px var(--c);
+}
+.tvp-marker--active {
+  transform: translate(-50%, -50%) scale(1.4);
+  box-shadow: 0 0 14px var(--c);
+}
+
+.tvp-time {
+  flex-shrink: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(255,255,255,0.85);
+  letter-spacing: 0.02em;
+  min-width: 90px;
+  text-align: right;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tvp-live-dot { animation: none; }
+  .tvp-fade-enter-active, .tvp-fade-leave-active { transition: opacity 0.2s; }
+}
+
+/* ── For Creators Card ── */
+.creator-card {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 22px 24px;
+  border-radius: 20px;
+  background: linear-gradient(135deg,
+    color-mix(in srgb, #10b981 6%, hsl(var(--card))) 0%,
+    hsl(var(--card)) 60%);
+  border: 1px solid color-mix(in srgb, #10b981 20%, hsl(var(--border)));
+  text-decoration: none;
+  overflow: hidden;
+  transition: transform 0.35s cubic-bezier(0.16, 1, 0.3, 1),
+              border-color 0.35s,
+              box-shadow 0.35s;
+}
+.creator-card:hover {
+  transform: translateY(-3px);
+  border-color: color-mix(in srgb, #10b981 50%, transparent);
+  box-shadow: 0 16px 40px -8px color-mix(in srgb, #10b981 25%, transparent);
+}
+.creator-icon {
+  flex-shrink: 0;
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #10b981;
+  background: linear-gradient(135deg, color-mix(in srgb, #10b981 18%, transparent), color-mix(in srgb, #10b981 5%, transparent));
+  border: 1px solid color-mix(in srgb, #10b981 30%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, #10b981 25%, transparent),
+              0 6px 18px -4px color-mix(in srgb, #10b981 45%, transparent);
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.creator-card:hover .creator-icon { transform: rotate(-6deg) scale(1.05); }
+.creator-title { font-size: 1.05rem; font-weight: 700; color: hsl(var(--foreground)); margin-bottom: 4px; letter-spacing: -0.01em; }
+.creator-desc  { font-size: 0.85rem; color: hsl(var(--muted-foreground)); line-height: 1.5; margin-bottom: 10px; }
+.creator-link  { display: inline-flex; align-items: center; gap: 6px; font-size: 0.85rem; font-weight: 600; color: #10b981; }
+.creator-arrow { transition: transform 0.25s; display: inline-block; }
+.creator-card:hover .creator-arrow { transform: translateX(4px); }
+
+.creator-yaml {
+  flex-shrink: 0;
+  display: none;
+}
+@media (min-width: 640px) { .creator-yaml { display: block; } }
+.creator-yaml-window {
+  width: 220px;
+  background: #0f172a;
+  border-radius: 10px;
+  padding: 26px 14px 14px;
+  position: relative;
+  border: 1px solid rgba(255,255,255,0.08);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.18);
+  font-family: ui-monospace, 'SF Mono', Monaco, monospace;
+  font-size: 11px;
+  line-height: 1.7;
+}
+.creator-yaml-dots {
+  position: absolute;
+  top: 8px; left: 10px;
+  display: flex; gap: 5px;
+}
+.creator-yaml-dots span {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: rgba(255,255,255,0.2);
+}
+.creator-yaml-dots span:nth-child(1) { background: #f87171; }
+.creator-yaml-dots span:nth-child(2) { background: #fbbf24; }
+.creator-yaml-dots span:nth-child(3) { background: #10b981; }
+.creator-yaml-line { color: #e2e8f0; white-space: nowrap; }
+.creator-yaml-indent { padding-left: 14px; }
+.creator-yaml-key { color: #818cf8; margin-right: 6px; }
+.creator-yaml-val { color: #34d399; }
+.creator-yaml-dash { color: #94a3b8; margin-right: 4px; }
+
+/* ── Privacy Cards ── */
+.privacy-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 16px 18px;
+  border-radius: 14px;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  transition: border-color 0.3s, box-shadow 0.3s;
+}
+.privacy-card:hover {
+  border-color: color-mix(in srgb, var(--c) 45%, transparent);
+  box-shadow: 0 6px 20px -6px color-mix(in srgb, var(--c) 22%, transparent);
+}
+.privacy-icon {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--c);
+  background: color-mix(in srgb, var(--c) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--c) 25%, transparent);
+}
+.privacy-title { font-size: 0.9rem; font-weight: 700; color: hsl(var(--foreground)); margin-bottom: 4px; letter-spacing: -0.01em; }
+.privacy-desc  { font-size: 0.78rem; color: hsl(var(--muted-foreground)); line-height: 1.5; }
+
+/* ── Roadmap ── */
+.roadmap-list {
+  position: relative;
+  padding-left: 26px;
+}
+.roadmap-list::before {
+  content: '';
+  position: absolute;
+  left: 11px; top: 14px; bottom: 14px;
+  width: 2px;
+  background: linear-gradient(180deg,
+    color-mix(in srgb, hsl(var(--primary)) 30%, transparent),
+    color-mix(in srgb, hsl(var(--primary)) 10%, transparent));
+  border-radius: 2px;
+}
+.roadmap-item {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  margin-bottom: 10px;
+  transition: border-color 0.25s, transform 0.25s;
+}
+.roadmap-item:hover {
+  transform: translateX(2px);
+  border-color: color-mix(in srgb, hsl(var(--primary)) 40%, transparent);
+}
+.roadmap-item--done {
+  border-color: color-mix(in srgb, #10b981 35%, transparent);
+  background: color-mix(in srgb, #10b981 5%, hsl(var(--card)));
+}
+.roadmap-dot {
+  position: absolute;
+  left: -22px;
+  top: 14px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: hsl(var(--background));
+  border: 2px solid hsl(var(--primary));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  z-index: 1;
+}
+.roadmap-item--done .roadmap-dot {
+  background: #10b981;
+  border-color: #10b981;
+}
+.roadmap-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+  margin-bottom: 2px;
+}
+.roadmap-item--done .roadmap-title {
+  color: hsl(var(--muted-foreground));
+  text-decoration: line-through;
+}
+.roadmap-desc  { font-size: 0.78rem; color: hsl(var(--muted-foreground)); line-height: 1.5; }
+.roadmap-issue {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: hsl(var(--muted-foreground));
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: color-mix(in srgb, hsl(var(--primary)) 8%, transparent);
+  text-decoration: none;
+  transition: background 0.2s, color 0.2s;
+}
+.roadmap-issue:hover { background: color-mix(in srgb, hsl(var(--primary)) 18%, transparent); color: hsl(var(--primary)); }
+
+/* ── Open Source CTA ── */
+.os-card {
+  position: relative;
+  padding: 32px 24px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #050810 0%, #131040 60%, #1e1b4b 100%);
+  border: 1px solid rgba(255,255,255,0.1);
+  overflow: hidden;
+  isolation: isolate;
+  box-shadow: 0 16px 40px -8px rgba(0,0,0,0.3);
+}
+.os-bg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 25% 30%, rgba(168,85,247,0.18), transparent 55%),
+    radial-gradient(ellipse at 75% 70%, rgba(16,185,129,0.15), transparent 55%);
+  pointer-events: none;
+}
+.os-content {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  max-width: 480px;
+  margin: 0 auto;
+}
+.os-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  border-radius: 18px;
+  margin-bottom: 16px;
+  background: rgba(255,255,255,0.1);
+  border: 1px solid rgba(255,255,255,0.2);
+  color: #fff;
+  filter: drop-shadow(0 0 12px rgba(255,255,255,0.2));
+}
+.os-title {
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: #f8fafc;
+  margin-bottom: 8px;
+  letter-spacing: -0.02em;
+}
+.os-desc {
+  font-size: 0.9rem;
+  color: rgba(248,250,252,0.75);
+  line-height: 1.6;
+  margin-bottom: 20px;
+}
+.os-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 22px;
+  border-radius: 999px;
+  background: #f8fafc;
+  color: #0f172a;
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.3);
+}
+.os-cta:hover {
+  transform: translateY(-2px);
+  background: #fff;
+  box-shadow: 0 10px 28px rgba(255,255,255,0.2);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .creator-card, .creator-icon, .creator-arrow, .roadmap-item, .os-cta { transition: none; }
+  .creator-card:hover, .creator-card:hover .creator-icon, .creator-card:hover .creator-arrow,
+  .roadmap-item:hover, .os-cta:hover { transform: none; }
+}
 
 /* ── How-It-Works Timeline (Sektion B) ── */
 .hiw-timeline { padding: 16px 0; }
@@ -740,23 +1626,100 @@ onUnmounted(() => {
   letter-spacing: -0.01em;
 }
 
-.hiw-action {
-  font-size: 0.85rem;
-  font-weight: 600;
-  padding: 8px 16px;
-  border-radius: 999px;
-  background: hsl(var(--primary));
-  color: hsl(var(--primary-foreground));
-  text-decoration: none;
-  transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
-  display: inline-flex;
-  box-shadow: 0 4px 12px color-mix(in srgb, hsl(var(--primary)) 30%, transparent);
-  margin-bottom: 8px;
+/* Step 1: animierte Sprechblase mit Audio-Wellen */
+.hiw-speak {
+  display: flex;
+  justify-content: center;
+  margin: 0 auto 14px;
+  width: 100px;
+  height: 70px;
 }
-.hiw-action:hover {
-  transform: translateY(-2px);
-  background: color-mix(in srgb, hsl(var(--primary)) 90%, white);
-  box-shadow: 0 8px 20px color-mix(in srgb, hsl(var(--primary)) 50%, transparent);
+.hiw-wave {
+  animation: hiw-wave-anim 1.5s ease-in-out infinite;
+  transform-origin: center;
+  transform-box: fill-box;
+}
+.hiw-wave-1 { animation-delay: 0s; }
+.hiw-wave-2 { animation-delay: 0.1s; }
+.hiw-wave-3 { animation-delay: 0.2s; }
+.hiw-wave-4 { animation-delay: 0.15s; }
+.hiw-wave-5 { animation-delay: 0.05s; }
+.hiw-wave-6 { animation-delay: 0.25s; }
+@keyframes hiw-wave-anim {
+  0%, 100% { stroke-dasharray: 0 14;   opacity: 0.4; }
+  50%      { stroke-dasharray: 14 0;   opacity: 1; }
+}
+
+/* Step 2: Workshop-Tiles im Karten-Mockup-Stil + animierter Cursor */
+.hiw-tiles {
+  position: relative;
+  display: flex;
+  gap: 7px;
+  margin: 4px auto 14px;
+  justify-content: center;
+  height: 42px;
+  width: 144px;
+}
+.hiw-tile {
+  position: relative;
+  width: 42px;
+  height: 38px;
+  border-radius: 6px;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08), 0 0 0 1px color-mix(in srgb, var(--tc) 12%, transparent);
+  overflow: hidden;
+  display: block;
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+/* Farbiger Top-Bar wie echte Workshop-Karten */
+.hiw-tile-bar {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 4px;
+  background: var(--tc);
+}
+/* Content-Linien (simulieren Titel + Beschreibung) */
+.hiw-tile-line {
+  position: absolute;
+  left: 5px;
+  height: 2px;
+  border-radius: 1px;
+  background: hsl(var(--muted-foreground));
+  opacity: 0.5;
+}
+.hiw-tile-line--w1 { top: 12px; width: 28px; opacity: 0.7; }
+.hiw-tile-line--w2 { top: 18px; width: 18px; opacity: 0.4; }
+
+/* Mittlere Karte „leuchtet auf" wenn der Cursor sie erreicht */
+.hiw-tile--2 {
+  animation: hiw-tile-glow 3s ease-in-out infinite;
+}
+@keyframes hiw-tile-glow {
+  0%, 38%, 75%, 100% {
+    transform: scale(1);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.08), 0 0 0 1px color-mix(in srgb, var(--tc) 12%, transparent);
+  }
+  50%, 60% {
+    transform: scale(1.08) translateY(-2px);
+    box-shadow: 0 6px 16px color-mix(in srgb, var(--tc) 35%, transparent),
+                0 0 0 2px color-mix(in srgb, var(--tc) 50%, transparent);
+  }
+}
+
+.hiw-cursor {
+  position: absolute;
+  color: hsl(var(--foreground));
+  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
+  animation: hiw-cursor-move 3s ease-in-out infinite;
+  pointer-events: none;
+}
+@keyframes hiw-cursor-move {
+  0%   { left: 8px;   top: 10px; transform: scale(1); }
+  35%  { left: 64px;  top: 16px; transform: scale(1); }
+  50%  { left: 64px;  top: 16px; transform: scale(0.8); }
+  60%  { left: 64px;  top: 16px; transform: scale(1); }
+  100% { left: 114px; top: 22px; transform: scale(1); }
 }
 
 .hiw-desc {
@@ -792,9 +1755,8 @@ onUnmounted(() => {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .hiw-line-fill, .hiw-num-glow, .hiw-bar { animation: none; }
+  .hiw-line-fill, .hiw-num-glow, .hiw-bar, .hiw-tile--2, .hiw-cursor, .hiw-wave { animation: none; }
   .hiw-step:hover .hiw-num { transform: none; }
-  .hiw-action:hover { transform: none; }
 }
 
 /* ── Feature Cards (Sektion A) ── */
@@ -967,5 +1929,220 @@ onUnmounted(() => {
 
 @media (prefers-reduced-motion: reduce) {
   .uc-track { animation: none; }
+}
+
+/* ══ PROVIDER CARD — Bezahlten Workshop anbieten ══ */
+.provider-card {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  padding: 1.8rem 1.8rem 1.5rem 1.8rem;
+  border-radius: 1.4rem;
+  color: #fff;
+  background:
+    linear-gradient(140deg, #0b1020 0%, #1a1240 55%, #0b1020 100%);
+  border: 1px solid rgba(124, 58, 237, 0.35);
+  box-shadow:
+    0 24px 60px -28px rgba(124, 58, 237, 0.7),
+    inset 0 0 0 1px rgba(255,255,255,0.04);
+}
+.provider-card__aurora {
+  position: absolute;
+  inset: -30%;
+  background:
+    radial-gradient(40% 50% at 18% 24%, rgba(124, 58, 237, 0.55), transparent 70%),
+    radial-gradient(35% 45% at 85% 78%, rgba(167, 139, 250, 0.4), transparent 72%),
+    radial-gradient(28% 38% at 65% 15%, rgba(34, 211, 238, 0.45), transparent 70%);
+  filter: blur(36px);
+  animation: providerAurora 22s ease-in-out infinite alternate;
+  z-index: 0;
+}
+.provider-card__grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px);
+  background-size: 28px 28px;
+  mask: linear-gradient(170deg, rgba(0,0,0,0.45) 0%, transparent 75%);
+  z-index: 0;
+}
+.provider-card__head { position: relative; z-index: 1; }
+.provider-card__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.32rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #fff;
+  background: linear-gradient(120deg, #7c3aed, #a78bfa, #22d3ee, #7c3aed);
+  background-size: 300% 100%;
+  animation: providerShift 7s ease-in-out infinite;
+  margin-bottom: 0.85rem;
+  box-shadow: 0 6px 18px -6px rgba(124, 58, 237, 0.8);
+}
+.provider-card__title {
+  font-size: clamp(1.4rem, 2.3vw, 1.85rem);
+  font-weight: 800;
+  line-height: 1.2;
+  margin: 0 0 0.5rem 0;
+  background: linear-gradient(120deg, #fff 30%, #d8b4fe 60%, #67e8f9);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.01em;
+}
+.provider-card__lead {
+  position: relative;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: rgba(255,255,255,0.78);
+  max-width: 70ch;
+  margin: 0 0 1.2rem 0;
+}
+.provider-card__cols {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 1.4rem;
+}
+@media (max-width: 720px) {
+  .provider-card__cols { grid-template-columns: 1fr; }
+}
+.provider-card__steps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+.provider-card__steps li {
+  display: flex;
+  gap: 0.8rem;
+  align-items: flex-start;
+}
+.provider-card__steps strong {
+  display: block;
+  font-size: 0.95rem;
+  color: #fff;
+  margin-bottom: 0.15rem;
+}
+.provider-card__steps p {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: rgba(255,255,255,0.72);
+}
+.provider-card__num {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  font-size: 0.85rem;
+  font-weight: 800;
+  color: #fff;
+  background: linear-gradient(135deg, #7c3aed, #a78bfa);
+  box-shadow: 0 4px 14px -4px rgba(124, 58, 237, 0.75),
+              inset 0 0 0 1px rgba(255,255,255,0.18);
+}
+.provider-card__yaml-window {
+  background: rgba(8, 12, 28, 0.85);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 0.85rem;
+  padding: 0.55rem 0 0.7rem 0;
+  box-shadow: 0 12px 28px -14px rgba(0,0,0,0.6);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+  overflow: hidden;
+}
+.provider-card__yaml-dots {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0 0.85rem 0.5rem 0.85rem;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.provider-card__yaml-dots span:not(.provider-card__yaml-file) {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+.provider-card__yaml-dots span:nth-child(1) { background: #ef4444; }
+.provider-card__yaml-dots span:nth-child(2) { background: #f59e0b; }
+.provider-card__yaml-dots span:nth-child(3) { background: #10b981; }
+.provider-card__yaml-file {
+  margin-left: auto;
+  font-size: 0.7rem;
+  color: rgba(255,255,255,0.5);
+}
+.provider-card__yaml-body {
+  margin: 0;
+  padding: 0.7rem 1rem 0.4rem 1rem;
+  color: rgba(255,255,255,0.88);
+  white-space: pre;
+  overflow-x: auto;
+}
+.provider-card__yaml-body .hl-key { color: #a78bfa; }
+.provider-card__yaml-body .hl-val { color: #67e8f9; }
+.provider-card__yaml-body .hl-num { color: #facc15; }
+.provider-card__yaml-body .hl-bool { color: #f472b6; }
+.provider-card__yaml-body .hl-comment { color: rgba(255,255,255,0.4); font-style: italic; }
+
+.provider-card__cta-row {
+  position: relative;
+  z-index: 1;
+  margin-top: 1.4rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+.provider-card__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.6rem 1.15rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.provider-card__cta--primary {
+  color: #fff;
+  background: linear-gradient(120deg, #7c3aed, #a78bfa);
+  box-shadow: 0 12px 26px -10px rgba(124, 58, 237, 0.85);
+}
+.provider-card__cta--primary:hover {
+  transform: translateY(-1px) scale(1.02);
+}
+.provider-card__cta--ghost {
+  color: rgba(255,255,255,0.9);
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.16);
+}
+.provider-card__cta--ghost:hover {
+  background: rgba(255,255,255,0.14);
+}
+
+@keyframes providerAurora {
+  0% { transform: translate3d(-3%, -3%, 0) rotate(0deg); }
+  100% { transform: translate3d(3%, 4%, 0) rotate(6deg); }
+}
+@keyframes providerShift {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .provider-card__aurora,
+  .provider-card__badge { animation: none; }
 }
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -589,7 +589,7 @@ import { useLanguage } from '../composables/useLanguage'
 import { formatLangName } from '../utils/formatters'
 
 const router = useRouter()
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const { availableContent, isLoading, loadAvailableContent } = useLessons()
 const { selectedLanguage, getFlag, setLanguage } = useLanguage()
 
@@ -613,6 +613,9 @@ function onScroll() {
 
 const learningLanguages = computed(() => [...new Set(Object.keys(availableContent.value))])
 const currentLanguage = computed(() => selectedLanguage.value || learningLanguages.value[0] || 'english')
+
+// Robust DE check: vue-i18n locale ist immer gesetzt, selectedLanguage kann null sein
+const isDE = computed(() => locale.value === 'de' || selectedLanguage.value === 'deutsch')
 
 // Seeded stars
 const stars = Array.from({ length: 55 }, (_, i) => ({


### PR DESCRIPTION
## Summary

Schliesst kommendes Issue.

Anbieter, die ueber Open Learn verkaufen wollen, finden auf der Startseite jetzt eine prominente Sektion mit der Erklaerung wie es geht.

## Was sich aendert

- Neue Sektion auf der Home (`/#/`) zwischen den bestehenden Bloecken: "Verkaufe deinen Kurs ueber Open Learn"
- Aurora-Hintergrund passend zum Premium-Look (cyan + violett)
- 4 nummerierte Schritte: YAML schreiben → Frei vs. Premium → Verkaufsseite verlinken → Importieren lassen
- Live-YAML-Snippet rechts mit den `premium:`-Feldern zur Anschauung
- 2 CTAs: "Live-Demo ansehen" + "Workshop-Guide oeffnen"

Andere Home-Sektionen unveraendert.

Spec: [`specs/creator-onboarding-on-home.md`](https://github.com/openlearnapp/openlearnapp.github.io/blob/feat/creators-onboarding-on-home/specs/creator-onboarding-on-home.md)

## Test plan

- [ ] Home oeffnen, scrollen bis "Fuer Kursanbieter"-Badge
- [ ] Aurora-Hintergrund laeuft animiert
- [ ] 4 Schritte sichtbar mit nummerierten lila Boxes
- [ ] YAML-Snippet rendert mit Syntax-Highlights (cyan/violett/gelb)
- [ ] Klick "Live-Demo ansehen" → fuehrt in die Lessons-Overview eines Premium-Workshops
- [ ] Klick "Workshop-Guide oeffnen" → /#/creators
- [ ] Sektionen darueber und darunter unveraendert

## Abhaengigkeit

Setzt PR #294 voraus.