### PR TITLE
feat: video-lock per lesson — section.video.premium

### DIFF
--- a/specs/video-lock-per-lesson.md
+++ b/specs/video-lock-per-lesson.md
@@ -1,0 +1,57 @@
+# Video-Lock pro Lektion — Text frei, Video gesperrt
+
+## Problem
+
+Premium-Sperre liegt heute nur auf Lektion-Ebene (PR #294). Anbieter wollen aber häufig eine Lektion **textlich frei** anbieten (als Vorgeschmack) und nur das **Video** sperren — der Lernende kann den Text lesen, aber für das Video muss er kaufen.
+
+## Lösung — Schema-Erweiterung
+
+In `content.yaml` darf `section.video` jetzt zwei Formen haben:
+
+```yaml
+sections:
+  # Variante A — wie heute, String, frei
+  - title: "Frei"
+    video: "https://youtube.com/..."
+
+  # Variante B — Object mit Premium-Flag
+  - title: "Gesperrt"
+    explanation: |
+      Dieser Text ist frei lesbar.
+    video:
+      url: "https://youtube.com/..."
+      premium: true                  # Video gesperrt bis Kauf
+      preview_image: "vorschau.png"   # optional — gedimmtes Standbild
+```
+
+Alte YAMLs mit `section.video: "..."` als String funktionieren weiter, unverändert.
+
+## Rendering
+
+Drei Fälle:
+
+| Fall | Was gerendert wird |
+|---|---|
+| `section.video` ist String | normaler Video-Player (wie heute) |
+| `section.video.premium: true` + Workshop ist freigeschaltet | normaler Player mit `section.video.url` |
+| `section.video.premium: true` + Workshop ist NICHT freigeschaltet | **PremiumVideoLock-Block** statt Player |
+
+### PremiumVideoLock-Block
+
+- Falls `preview_image` gesetzt: gedimmtes Standbild als Hintergrund (16:9)
+- Falls nicht: dunkler Aurora-Hintergrund mit Premium-Akzent
+- Mittig zentriert: cyan glühender Schloss-Indikator (gleicher Glow-Stil wie auf `LockedLessonCard`)
+- Darunter: kleine Zeile „Video freischalten" oder „Mit Kauf freigeschaltet"
+- Klick auf den Block öffnet `provider.landing_url` in neuem Tab
+
+Section-Text (Markdown-Erklärung, Beispiele, Quizze) **bleibt voll lesbar** — der Lock greift nur auf das Video.
+
+## Was unverändert bleibt
+
+- Lektion-Ebene-Sperre (`free_lessons` / `free_lesson_numbers`) — wirkt weiter unverändert
+- Bestehende kostenlose Workshops — unangetastet
+- Antwort-Speicherung, Audio, Coach-Forwarding — wie heute
+
+## Abhängigkeit
+
+Setzt PR #294 (Backbone) voraus — nutzt `usePremium.isUnlocked()` und `provider.landing_url` aus `workshopMetaData`.

--- a/src/components/PremiumVideoLock.vue
+++ b/src/components/PremiumVideoLock.vue
@@ -1,0 +1,148 @@
+<template>
+  <div
+    class="pvl"
+    :style="boxStyle"
+    role="button"
+    tabindex="0"
+    :aria-label="label"
+    @click.stop="$emit('unlock')"
+    @keydown.enter.prevent="$emit('unlock')"
+    @keydown.space.prevent="$emit('unlock')">
+    <img v-if="previewImage" :src="previewImage" :alt="label" class="pvl__bg-img" />
+    <div v-else class="pvl__bg-fallback" aria-hidden="true">
+      <div class="pvl__aurora"></div>
+    </div>
+    <div class="pvl__veil" aria-hidden="true"></div>
+    <div class="pvl__lock" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="32" height="32" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="5" y="11" width="14" height="9" rx="2"/>
+        <path d="M8 11V7a4 4 0 0 1 8 0v4"/>
+      </svg>
+    </div>
+    <div class="pvl__hint">{{ label }}</div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  previewImage: { type: String, default: '' },
+  accent: { type: String, default: '#22d3ee' },
+  accentSoft: { type: String, default: '#67e8f9' },
+  label: { type: String, default: 'Video freischalten' }
+})
+
+defineEmits(['unlock'])
+
+const boxStyle = computed(() => ({
+  '--pvl-a': props.accent,
+  '--pvl-b': props.accentSoft
+}))
+</script>
+
+<style scoped>
+.pvl {
+  --pvl-a: #22d3ee;
+  --pvl-b: #67e8f9;
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 0.6rem;
+  overflow: hidden;
+  cursor: pointer;
+  isolation: isolate;
+  background: rgb(15, 23, 42);
+  border: 1px solid color-mix(in oklab, var(--pvl-a) 28%, rgba(255,255,255,0.06));
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+}
+.pvl:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in oklab, var(--pvl-a) 60%, transparent);
+  box-shadow: 0 14px 36px -14px color-mix(in oklab, var(--pvl-a) 70%, transparent);
+}
+.pvl:focus-visible {
+  outline: 2px solid var(--pvl-b);
+  outline-offset: 3px;
+}
+
+.pvl__bg-img {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  filter: saturate(0.85) brightness(0.6);
+  z-index: 0;
+}
+
+.pvl__bg-fallback {
+  position: absolute; inset: 0;
+  z-index: 0;
+  background: linear-gradient(140deg, #0a0e22 0%, #1a1140 55%, #0a0e22 100%);
+}
+
+.pvl__aurora {
+  position: absolute; inset: -30%;
+  background:
+    radial-gradient(40% 50% at 20% 30%, color-mix(in oklab, var(--pvl-a) 55%, transparent), transparent 70%),
+    radial-gradient(35% 50% at 80% 70%, color-mix(in oklab, var(--pvl-b) 40%, transparent), transparent 72%);
+  filter: blur(36px);
+  animation: pvlAurora 22s ease-in-out infinite alternate;
+}
+
+.pvl__veil {
+  position: absolute; inset: 0;
+  z-index: 1;
+  background:
+    linear-gradient(135deg, color-mix(in oklab, var(--pvl-a) 20%, transparent), transparent 60%),
+    linear-gradient(0deg, rgba(0,0,0,0.5), rgba(0,0,0,0.15));
+  pointer-events: none;
+}
+
+.pvl__lock {
+  position: absolute; top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+  width: 64px; height: 64px;
+  display: grid; place-items: center;
+  color: var(--pvl-b);
+  border-radius: 999px;
+  background: radial-gradient(circle at 50% 50%, color-mix(in oklab, var(--pvl-a) 35%, transparent), color-mix(in oklab, var(--pvl-a) 8%, transparent) 70%);
+  box-shadow:
+    0 0 18px color-mix(in oklab, var(--pvl-a) 60%, transparent),
+    0 0 36px color-mix(in oklab, var(--pvl-a) 30%, transparent),
+    inset 0 0 0 1px color-mix(in oklab, var(--pvl-b) 50%, transparent);
+  filter: drop-shadow(0 0 8px color-mix(in oklab, var(--pvl-a) 70%, transparent));
+  animation: pvlFlicker 3.6s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.pvl__hint {
+  position: absolute;
+  bottom: 14px; left: 50%;
+  transform: translateX(-50%);
+  z-index: 2;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #fff;
+  background: rgba(8, 12, 28, 0.7);
+  border: 1px solid color-mix(in oklab, var(--pvl-a) 45%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+@keyframes pvlAurora {
+  0% { transform: translate3d(-3%, -3%, 0) rotate(0deg); }
+  100% { transform: translate3d(3%, 4%, 0) rotate(6deg); }
+}
+@keyframes pvlFlicker {
+  0%, 100% { opacity: 0.85; }
+  42% { opacity: 1; }
+  55% { opacity: 0.7; }
+  65% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pvl__aurora, .pvl__lock { animation: none; }
+}
+</style>

--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -74,29 +74,39 @@
         </CardHeader>
         <CardContent class="p-0">
           <div v-if="section.video && !activeLabel && !isInFocusMode" class="mb-4">
-            <iframe
-              v-if="isYouTubeUrl(section.video)"
-              :src="normalizeVideoUrl(section.video)"
-              class="w-full aspect-video rounded"
-              frameborder="0"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-              allowfullscreen>
-            </iframe>
-            <iframe
-              v-else-if="isHtmlVideoUrl(section.video)"
-              :src="resolveVideoPath(section.video)"
-              class="w-full aspect-video rounded"
-              frameborder="0"
-              allow="autoplay; fullscreen"
-              loading="lazy">
-            </iframe>
-            <video
-              v-else
-              :src="resolveVideoPath(section.video)"
-              class="w-full aspect-video rounded"
-              controls
-              preload="metadata">
-            </video>
+            <!-- Premium video lock: object form with premium: true, workshop not unlocked -->
+            <PremiumVideoLock
+              v-if="isVideoLocked(section.video)"
+              :preview-image="resolveVideoPreviewImage(section.video)"
+              :accent="workshopProvider?.accent_color || '#22d3ee'"
+              :accent-soft="workshopProvider?.accent_color_soft || '#67e8f9'"
+              :label="$t('lesson.unlockVideo') || (isDE ? 'Video freischalten' : 'Unlock video')"
+              @unlock="openProviderLanding" />
+            <template v-else>
+              <iframe
+                v-if="isYouTubeUrl(videoUrl(section.video))"
+                :src="normalizeVideoUrl(videoUrl(section.video))"
+                class="w-full aspect-video rounded"
+                frameborder="0"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen>
+              </iframe>
+              <iframe
+                v-else-if="isHtmlVideoUrl(videoUrl(section.video))"
+                :src="resolveVideoPath(videoUrl(section.video))"
+                class="w-full aspect-video rounded"
+                frameborder="0"
+                allow="autoplay; fullscreen"
+                loading="lazy">
+              </iframe>
+              <video
+                v-else
+                :src="resolveVideoPath(videoUrl(section.video))"
+                class="w-full aspect-video rounded"
+                controls
+                preload="metadata">
+              </video>
+            </template>
           </div>
 
           <!-- Lightbox -->
@@ -338,6 +348,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useLessons } from '../composables/useLessons'
 import { usePremium } from '../composables/usePremium'
+import PremiumVideoLock from '@/components/PremiumVideoLock.vue'
 import { useSettings } from '../composables/useSettings'
 import { useProgress } from '../composables/useProgress'
 import { useAudio } from '../composables/useAudio'
@@ -472,6 +483,40 @@ function resolveLessonAssetPath(assetPath) {
 
 function resolveVideoPath(videoPath) {
   return resolveLessonAssetPath(videoPath)
+}
+
+// Premium video helpers — accept both string (legacy) and object form
+function videoUrl(v) {
+  if (!v) return ''
+  return typeof v === 'string' ? v : (v.url || '')
+}
+
+function videoIsPremium(v) {
+  return v && typeof v === 'object' && v.premium === true
+}
+
+function isVideoLocked(v) {
+  if (!videoIsPremium(v)) return false
+  const wsMeta = getWorkshopMeta(learning.value, workshop.value)
+  if (!wsMeta?.premium) return false
+  return !premiumGuard.isUnlocked(learning.value, workshop.value)
+}
+
+const isDE = computed(() => learning.value === 'deutsch')
+
+function resolveVideoPreviewImage(v) {
+  if (!v || typeof v !== 'object' || !v.preview_image) return ''
+  return resolveLessonAssetPath(v.preview_image)
+}
+
+const workshopProvider = computed(() => {
+  const wsMeta = getWorkshopMeta(learning.value, workshop.value)
+  return wsMeta?.provider || null
+})
+
+function openProviderLanding() {
+  const url = workshopProvider.value?.landing_url
+  if (url) window.open(url, '_blank', 'noopener')
 }
 
 function resolveImagePath(imagePath) {


### PR DESCRIPTION
## Summary

Closes #295.

Anbieter koennen jetzt eine Lektion textlich frei anbieten und nur das Video sperren. Lernende lesen den Text, Video-Player wird durch PremiumVideoLock-Block ersetzt bis zum Kauf.

## Was sich aendert

- **Schema** in content.yaml: section.video darf zwei Formen haben — String wie heute (frei) oder Object `{url, premium, preview_image}` fuer Premium-Video. Bestehende YAMLs bleiben funktional.
- **`PremiumVideoLock.vue`** (neu) — gedimmtes preview_image als Hintergrund, cyan gluehendes Schloss zentral, Pill "Video freischalten" unten. Klick oeffnet provider.landing_url.
- **`LessonDetail.vue`** rendert die Video-Sektion conditional: String oder freigeschalteter Premium-Video → normaler Player; gesperrter Premium-Video → PremiumVideoLock.

Section-Text bleibt voll lesbar — der Lock greift nur auf das Video.

Spec: [`specs/video-lock-per-lesson.md`](https://github.com/openlearnapp/openlearnapp.github.io/blob/feat/video-lock-per-lesson/specs/video-lock-per-lesson.md)

## Test plan

- [ ] Lektion mit `section.video: "https://..."` (String) → normaler Player wie heute
- [ ] Lektion mit `section.video: { url, premium: true, preview_image }` in Premium-Workshop, NICHT freigeschaltet → PremiumVideoLock mit Bild als Hintergrund + cyan Schloss
- [ ] Klick auf den Lock-Block → provider.landing_url oeffnet neuer Tab
- [ ] Section-Text + Quizze unter dem Video bleiben voll bedienbar
- [ ] Nach Demo-Unlock im Banner → Lock weg, normaler Player erscheint
- [ ] Premium-Video in einem Premium-Workshop OHNE preview_image → Aurora-Fallback-Hintergrund

## Abhaengigkeit

Setzt PR #294 voraus.