### PR TITLE
feat: auto-unlock workshop via URL token after provider checkout

### DIFF
--- a/specs/auto-unlock-via-url-token.md
+++ b/specs/auto-unlock-via-url-token.md
@@ -1,0 +1,49 @@
+# Auto-Unlock per URL-Token nach Kauf-Rückkehr
+
+## Problem
+
+Heute ist der Premium-Workshop nur per „Demo entsperren"-Knopf im Banner freischaltbar — als Vorschau. Echte Käufer haben aber keinen Weg, ihren Kauf in der App zu aktivieren. Der Kauf-Flow ist offen: Anbieter-Landing-Page → Checkout → ??? → kein direkter Übergang zurück in Open Learn mit aktivem Premium.
+
+Das `unlock_token`-Feld im Workshop-Schema ist seit PR #294 reserviert, aber noch nicht ausgewertet.
+
+## Lösung
+
+Anbieter leitet den Käufer nach erfolgreichem Kauf zurück auf die Open-Learn-URL des Workshops mit `?unlock=<token>` als URL-Parameter. Die App vergleicht den Token mit dem `unlock_token`-Feld aus `workshops.yaml` und entsperrt den Workshop bei Match **persistent** für diesen Lernenden (gleiche LocalStorage-Schicht wie Demo-Unlock).
+
+### Beispiel
+
+```
+https://open-learn.app/#/deutsch/linux-grundlagen/lessons?unlock=linuxpfad-2026-abc123
+```
+
+Wenn `workshops.yaml` hat:
+
+```yaml
+premium: true
+unlock_token: "linuxpfad-2026-abc123"
+```
+
+→ Match → App entsperrt den Workshop, zeigt grünen Toast „Workshop freigeschaltet — viel Spaß beim Lernen!"
+
+Bei Mismatch oder fehlendem Token → kein Unlock, kein Toast, normale Schloss-Anzeige.
+
+### Saubere URL nach Unlock
+
+Nach erfolgreichem Unlock wird der `?unlock=`-Param aus der URL entfernt (per `router.replace`), damit der Token nicht im Browser-Verlauf und Bookmark hängen bleibt.
+
+## Was unverändert bleibt
+
+- „Demo entsperren"-Knopf im Banner — bleibt für Reviewer
+- LocalStorage-Schicht — gleiche Persistenz wie Demo-Unlock
+- Anbieter-Workshop ohne `unlock_token` — Param wird ignoriert, kein Auto-Unlock möglich
+- Kostenlose Workshops — Param wird ignoriert
+
+## Sicherheits-Hinweis
+
+Der Token ist **gemeinsam vom Anbieter und allen Lernenden bekannt** — er ist in `workshops.yaml` öffentlich. Das ist explizit so gewollt: Open Learn macht hier kein Account-System, sondern eine Path-as-Secret-Variante. Der eigentliche Schutz liegt bei der Anbieter-URL und beim Anbieter-Backend (nur zahlende Kunden bekommen den Token-Link per Mail). Wer den Token findet, kann den Workshop entsperren — Open Learn ist hier nicht der Zahlungs-Gatekeeper.
+
+Für stärkeren Schutz kann der Anbieter pro Käufer eindeutige Tokens generieren und in einer separaten YAML-Quelle bereitstellen, deren Auto-Discovery-Mechanik in einer späteren Iteration spezifiziert wird.
+
+## Abhängigkeit
+
+Setzt PR #294 (Backbone) voraus — nutzt `meta.unlock_token` und `usePremium.unlock()`.

--- a/src/composables/usePremium.js
+++ b/src/composables/usePremium.js
@@ -56,12 +56,25 @@ export function usePremium() {
     return isLessonFree(meta, lessonIndex, lessonNumber)
   }
 
+  // Attempt to unlock the workshop from a URL token, comparing against the
+  // workshop's unlock_token field. Returns true on success, false on no-op.
+  function tryUnlockFromToken(lang, workshop, meta, token) {
+    if (!token) return false
+    if (!meta?.premium) return false
+    if (!meta?.unlock_token) return false
+    if (meta.unlock_token !== token) return false
+    if (isUnlocked(lang, workshop)) return true
+    unlock(lang, workshop)
+    return true
+  }
+
   return {
     unlocked,
     isUnlocked,
     unlock,
     lock,
     isLessonFree,
-    isLessonAccessible
+    isLessonAccessible,
+    tryUnlockFromToken
   }
 }

--- a/src/views/LessonsOverview.vue
+++ b/src/views/LessonsOverview.vue
@@ -1,5 +1,15 @@
 <template>
   <div>
+    <!-- Unlock-success toast after URL-token unlock -->
+    <Transition name="unlock-toast">
+      <div v-if="unlockToast" class="unlock-toast" role="status">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M20 6 9 17l-5-5"/>
+        </svg>
+        <span>{{ unlockToast }}</span>
+      </div>
+    </Transition>
+
     <!-- Source indicator (alle Workshops) -->
     <div v-if="!isLoading && !isLinuxWorkshop && (isRemote || lessons.length > 0)" class="mb-4 flex items-center justify-between text-sm">
       <div>
@@ -448,6 +458,27 @@ async function loadLessons() {
 
   const meta = getWorkshopMeta(learning.value, workshop.value)
   emit('update-title', meta.title || formatLangName(workshop.value))
+
+  // Auto-unlock from URL token after returning from provider checkout
+  checkUnlockToken(meta)
+}
+
+const unlockToast = ref(null)
+
+function checkUnlockToken(meta) {
+  const token = route.query.unlock
+  if (!token) return
+  const ok = premium.tryUnlockFromToken(learning.value, workshop.value, meta, token)
+  if (ok) {
+    unlockToast.value = isDE.value
+      ? 'Workshop freigeschaltet — viel Spaß beim Lernen!'
+      : 'Workshop unlocked — enjoy learning!'
+    setTimeout(() => { unlockToast.value = null }, 5000)
+  }
+  // Clean ?unlock= from URL either way so it doesn't stick in history/bookmarks
+  const cleanQuery = { ...route.query }
+  delete cleanQuery.unlock
+  router.replace({ query: cleanQuery })
 }
 
 watch([learning, workshop], () => {
@@ -542,6 +573,38 @@ onUnmounted(() => {
 /* Lektionen-Bereich — Farbe über Tailwind dark: Klasse im Template */
 .unit-lessons {
   /* background via bg-white dark:bg-[#0d1320] im Template */
+}
+
+/* Unlock-Success-Toast nach Kauf-Rückkehr per ?unlock=<token> */
+.unlock-toast {
+  position: fixed;
+  top: 1.2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.7rem 1.1rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: #064e3b;
+  background: linear-gradient(120deg, #6ee7b7, #34d399);
+  border: 1px solid rgba(16, 185, 129, 0.55);
+  box-shadow: 0 14px 32px -12px rgba(16, 185, 129, 0.7);
+}
+:global(.dark) .unlock-toast {
+  color: #ecfdf5;
+  background: linear-gradient(120deg, rgba(16, 185, 129, 0.32), rgba(20, 184, 166, 0.32));
+  border-color: rgba(110, 231, 183, 0.45);
+}
+.unlock-toast-enter-active, .unlock-toast-leave-active {
+  transition: opacity 0.35s ease, transform 0.35s cubic-bezier(.2,.9,.2,1);
+}
+.unlock-toast-enter-from, .unlock-toast-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(-12px);
 }
 
 /* Provider-Banner direkt im unit-frame — nahtlos angeschlossen an den Trailer */


### PR DESCRIPTION
## Summary

Schliesst kommendes Issue. Schliesst den Kauf-Flow: Anbieter schickt nach Kauf zurueck mit `?unlock=<token>`, App entsperrt automatisch und persistent.

## Was sich aendert

- **`usePremium.js`** — neue Funktion `tryUnlockFromToken(lang, workshop, meta, token)`: prueft `meta.premium` und `meta.unlock_token` gegen den uebergebenen Token, ruft `unlock()` bei Match.
- **`LessonsOverview.vue`** — beim Mount auf `?unlock=` Param pruefen, Funktion aufrufen. Bei Erfolg gruener Toast oben fuer 5 Sekunden. URL wird in beiden Faellen via `router.replace` von dem Param befreit, damit er nicht in History/Bookmarks haengen bleibt.

## Test plan

In einem Premium-Workshop (`premium: true` + `unlock_token: "abc"` in workshops.yaml):

- [ ] URL mit korrektem Token oeffnen: `#/.../lessons?unlock=abc` → gruener Toast erscheint kurz, Workshop ist entsperrt (Schloesser weg), URL ist auf `#/.../lessons` gekuerzt
- [ ] Seite neu laden ohne Token → bleibt entsperrt (LocalStorage persistent)
- [ ] URL mit falschem Token: `?unlock=xyz` → kein Toast, kein Unlock, URL trotzdem gekuerzt
- [ ] Kostenloser Workshop mit `?unlock=irgendwas` → ignoriert
- [ ] "Demo entsperren" Knopf im Banner funktioniert weiter wie heute

## Sicherheits-Hinweis

Der Token in `workshops.yaml` ist oeffentlich (Path-as-Secret). Schutz liegt beim Anbieter-Backend, das nur zahlende Kaeufer den Token-Link bekommen laesst. Pro-Kaeufer-Tokens sind in einer spaeteren Iteration moeglich, falls Anbieter staerkeren Schutz wollen.

## Abhaengigkeit

Setzt PR #294 voraus.